### PR TITLE
ENH: Add generate auth token

### DIFF
--- a/src/fmu/settings/cli/api_server.py
+++ b/src/fmu/settings/cli/api_server.py
@@ -6,16 +6,16 @@ from fmu.settings.api import run_server
 
 
 def start_api_server(
+    token: str,
     host: str = "127.0.0.1",
     port: int = 8001,
 ) -> None:
     """Starts the fmu-settings-api server.
 
     Args:
-        host (str): The host to bind the server to
-        port (int): The port to run the server on
-        reload (bool): Whether to enable auto-reload
-        wait (bool): Whether to wait for the server to complete (blocking)
+        token: The authentication token the API uses
+        host: The host to bind the server to
+        port: The port to run the server on
     """
     try:
         print(f"Starting FMU Settings API server on {host}:{port}...")

--- a/src/fmu/settings/cli/gui_server.py
+++ b/src/fmu/settings/cli/gui_server.py
@@ -6,14 +6,16 @@ from fmu.settings.gui import run_server
 
 
 def start_gui_server(
+    token: str,
     host: str = "127.0.0.1",
     port: int = 8000,
 ) -> None:
     """Starts the fmu-settings-api server.
 
     Args:
-        host (str): The host to bind the server to
-        port (int): The port to run the server on
+        token: The authentication token the GUI uses
+        host: The host to bind the server to
+        port: The port to run the server on
     """
     try:
         print(f"Starting FMU Settings GUI server on {host}:{port}...")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,32 +1,80 @@
 """Tests for the __main__ module."""
 
-from unittest import mock
+import sys
+from unittest.mock import MagicMock, patch
 
-from fmu.settings.cli import __main__
+from fmu.settings.cli.__main__ import (
+    _parse_args,
+    generate_auth_token,
+    main,
+    start_api_and_gui,
+)
+
+
+def test_parse_args_no_input() -> None:
+    """Tests that parse_args falls back to sys.argv."""
+    expected = 9999
+    with patch.object(sys, "argv", ["fmu-settings", "api", "--port", str(expected)]):
+        args = _parse_args()
+    assert args.port == expected
 
 
 def test_main_invocation_with_no_options() -> None:
     """Tests that fmu-settings calls 'start_api_and_gui'."""
-    with mock.patch(
-        "fmu.settings.cli.__main__.start_api_and_gui"
-    ) as mock_start_api_and_gui:
-        __main__.main([])
+    with patch("fmu.settings.cli.__main__.start_api_and_gui") as mock_start_api_and_gui:
+        main([])
         mock_start_api_and_gui.assert_called_once()
 
 
 def test_main_invocation_with_api_subcommand() -> None:
     """Tests that fmu-settings calls 'start_api_and_gui'."""
-    with mock.patch(
-        "fmu.settings.cli.__main__.start_api_server"
-    ) as mock_start_api_server:
-        __main__.main(["api"])
+    with patch("fmu.settings.cli.__main__.start_api_server") as mock_start_api_server:
+        main(["api"])
         mock_start_api_server.assert_called_once()
 
 
 def test_main_invocation_with_gui_subcommand() -> None:
     """Tests that fmu-settings calls 'start_api_and_gui'."""
-    with mock.patch(
-        "fmu.settings.cli.__main__.start_gui_server"
-    ) as mock_start_gui_server:
-        __main__.main(["gui"])
+    with patch("fmu.settings.cli.__main__.start_gui_server") as mock_start_gui_server:
+        main(["gui"])
         mock_start_gui_server.assert_called_once()
+
+
+def test_generate_auth_token() -> None:
+    """Tests generating an authentication token."""
+    assert len(generate_auth_token()) == 64  # noqa
+    assert generate_auth_token() != generate_auth_token() != generate_auth_token()
+
+
+def test_start_api_and_gui_threads() -> None:
+    """Tests that all three threads are started."""
+    token = generate_auth_token()
+    args = MagicMock()
+    with (
+        patch("fmu.settings.cli.__main__.start_api_server") as mock_start_api_server,
+        patch("fmu.settings.cli.__main__.start_gui_server") as mock_start_gui_server,
+        patch("fmu.settings.cli.__main__.webbrowser.open") as mock_webbrowser_open,
+    ):
+        start_api_and_gui(token, args)
+        mock_start_api_server.assert_called_once()
+        mock_start_gui_server.assert_called_once()
+        mock_webbrowser_open.assert_called_once()
+
+
+def test_keyboard_interrupt_kills_threads() -> None:
+    """Tests that all three threads are started and killed on a KeyboardInterrupt."""
+    token = generate_auth_token()
+    args = MagicMock()
+    with (
+        patch("fmu.settings.cli.__main__.start_api_server") as mock_start_api_server,
+        patch("fmu.settings.cli.__main__.start_gui_server") as mock_start_gui_server,
+        patch(
+            "fmu.settings.cli.__main__.webbrowser.open", side_effect=KeyboardInterrupt
+        ) as mock_webbrowser_open,
+        patch("fmu.settings.cli.__main__.sys.exit") as mock_sys_exit,
+    ):
+        start_api_and_gui(token, args)
+        mock_start_api_server.assert_called_once()
+        mock_start_gui_server.assert_called_once()
+        mock_webbrowser_open.assert_called_once()
+        mock_sys_exit.assert_called_once()

--- a/tests/test_start_api_server.py
+++ b/tests/test_start_api_server.py
@@ -1,0 +1,29 @@
+"""Tests for api_server.py."""
+
+import socket
+from unittest.mock import patch
+
+from fmu.settings.cli.__main__ import generate_auth_token
+from fmu.settings.cli.api_server import start_api_server
+
+
+def test_start_api_server() -> None:
+    """Tests that start_api_server calls as expected."""
+    token = generate_auth_token()
+    with patch("fmu.settings.cli.api_server.run_server") as mock_run_server:
+        start_api_server(token)
+        mock_run_server.assert_called_once()
+
+
+def test_start_api_server_fails() -> None:
+    """Tests that start_api_server failing raises an exception."""
+    token = generate_auth_token()
+    with (
+        patch(
+            "fmu.settings.cli.api_server.run_server", side_effect=socket.error
+        ) as mock_run_server,
+        patch("fmu.settings.cli.api_server.sys.exit") as mock_sys_exit,
+    ):
+        start_api_server(token)
+        mock_run_server.assert_called_once()
+        mock_sys_exit.assert_called_once()

--- a/tests/test_start_gui_server.py
+++ b/tests/test_start_gui_server.py
@@ -1,0 +1,29 @@
+"""Tests for gui_server.py."""
+
+import socket
+from unittest.mock import patch
+
+from fmu.settings.cli.__main__ import generate_auth_token
+from fmu.settings.cli.gui_server import start_gui_server
+
+
+def test_start_gui_server() -> None:
+    """Tests that start_api_server calls as expected."""
+    token = generate_auth_token()
+    with patch("fmu.settings.cli.gui_server.run_server") as mock_run_server:
+        start_gui_server(token)
+        mock_run_server.assert_called_once()
+
+
+def test_start_api_server_fails() -> None:
+    """Tests that start_api_server failing raises an exception."""
+    token = generate_auth_token()
+    with (
+        patch(
+            "fmu.settings.cli.gui_server.run_server", side_effect=socket.error
+        ) as mock_run_server,
+        patch("fmu.settings.cli.gui_server.sys.exit") as mock_sys_exit,
+    ):
+        start_gui_server(token)
+        mock_run_server.assert_called_once()
+        mock_sys_exit.assert_called_once()


### PR DESCRIPTION
Resolves #1

Adds a generate token function to pass an authentication token to the API/GUI threads. It also passes it to the React app as URL fragment. Although our security concerns are less severe given we are executing on TGX nodes where users are already authenticated, this adds some additional protection against someone using the same node and navigating to `localhost:8000` and hijacking a session. It will also disallow un-authenticated post requests to the API.

Additional this adds some extra tests which were not added when the repository was initialized.

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
