### PR TITLE
FIX: Use new gui package name

### DIFF
--- a/src/fmu_settings_cli/gui_server.py
+++ b/src/fmu_settings_cli/gui_server.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from fmu.settings.gui import run_server
+from fmu_settings_gui import run_server
 
 
 def start_gui_server(


### PR DESCRIPTION
Resolves #7

It was moved out of the `fmu` namespace.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [ ] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
