### PR TITLE
ENH: Allow setting frontend host/port as API

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,19 @@ It is also possible to specify the port and if the API should be reloaded, as
 in during development.
 
 ```bash
-fmu-settings api --port 8001 --reload
+fmu-settings api --port 8001
 ```
+
+By default the API will set CORS rules restricting requests to a default host
+and port (`localhost:8000`). In development with a GUI it's likely your
+frontend port will be something different. You can specify this like so:
+
+```bash
+fmu-settings api --gui-port 5173
+```
+
+This will update the CORS rules in the API to accept requests from
+`localhost:5173`.
 
 You can similarly start the GUI server:
 

--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -59,6 +59,23 @@ def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
         help="Host to bind the API server to (default: 127.0.0.1)",
     )
     api_parser.add_argument(
+        "--gui-host",
+        type=str,
+        default="localhost",
+        help=(
+            "Host the GUI sends requests from. Sets the CORS host. (default: localhost)"
+        ),
+    )
+    api_parser.add_argument(
+        "--gui-port",
+        type=int,
+        default=8000,
+        help=(
+            "Port the GUI sends requests from. Sets the CORS port for the GUI host. "
+            "(default: 8000)"
+        ),
+    )
+    api_parser.add_argument(
         "--reload",
         action="store_true",
         help="Enable auto-reload for development",
@@ -145,7 +162,13 @@ def main(test_args: list[str] | None = None) -> None:
     token = generate_auth_token()
     match args.command:
         case "api":
-            start_api_server(token, host=args.host, port=args.port)
+            start_api_server(
+                token,
+                host=args.host,
+                port=args.port,
+                frontend_host=args.gui_host,
+                frontend_port=args.gui_port,
+            )
         case "gui":
             start_gui_server(token, host=args.host, port=args.port)
         case _:


### PR DESCRIPTION
Resolves #11

Allows setting the frontend/gui host/port in the `fmu-settings api` invocation. When set these should automatically update the CORS setting on the API side. They were previously defaulted.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
