### PR TITLE
ENH: Make default hosts and ports constants

### DIFF
--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -9,6 +9,7 @@ import webbrowser
 from concurrent.futures import ProcessPoolExecutor
 
 from .api_server import start_api_server
+from .constants import API_PORT, GUI_PORT, HOST
 from .gui_server import start_gui_server
 
 
@@ -22,20 +23,20 @@ def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--api-port",
         type=int,
-        default=8001,
-        help="Port to run the API on (default: 8001)",
+        default=API_PORT,
+        help=f"Port to run the API on (default: {API_PORT})",
     )
     parser.add_argument(
         "--gui-port",
         type=int,
-        default=8000,
-        help="Port to run the GUI on (default: 8000)",
+        default=GUI_PORT,
+        help=f"Port to run the GUI on (default: {GUI_PORT})",
     )
     parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
-        help="Host to bind the servers to (default: 127.0.0.1)",
+        default=HOST,
+        help=f"Host to bind the API and GUI servers to (default: {HOST})",
     )
     parser.add_argument(
         "--reload",
@@ -49,30 +50,30 @@ def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
     api_parser.add_argument(
         "--port",
         type=int,
-        default=8001,
-        help="Port to run the API on (default: 8001)",
+        default=API_PORT,
+        help=f"Port to run the API on (default: {API_PORT})",
     )
     api_parser.add_argument(
         "--host",
         type=str,
-        default="127.0.0.1",
-        help="Host to bind the API server to (default: 127.0.0.1)",
+        default=HOST,
+        help=f"Host to bind the API server to (default: {HOST})",
     )
     api_parser.add_argument(
         "--gui-host",
         type=str,
-        default="localhost",
+        default=HOST,
         help=(
-            "Host the GUI sends requests from. Sets the CORS host. (default: localhost)"
+            f"Host the GUI sends requests from. Sets the CORS host. (default: {HOST})"
         ),
     )
     api_parser.add_argument(
         "--gui-port",
         type=int,
-        default=8000,
+        default=GUI_PORT,
         help=(
-            "Port the GUI sends requests from. Sets the CORS port for the GUI host. "
-            "(default: 8000)"
+            "Port the GUI sends requests from. Sets the CORS port. "
+            f"(default: {GUI_PORT})"
         ),
     )
     api_parser.add_argument(
@@ -85,14 +86,14 @@ def _parse_args(args: list[str] | None = None) -> argparse.Namespace:
     gui_parser.add_argument(
         "--port",
         type=int,
-        default=8000,
-        help="Port to run the GUI on (default: 8000)",
+        default=GUI_PORT,
+        help=f"Port to run the GUI on (default: {GUI_PORT})",
     )
     gui_parser.add_argument(
         "--host",
         type=str,
-        default="localhost",
-        help="Host to bind the GUI server to (default: localhost)",
+        default=HOST,
+        help=f"Host to bind the GUI server to (default: {HOST})",
     )
 
     return parser.parse_args(args)
@@ -140,7 +141,7 @@ def start_api_and_gui(token: str, args: argparse.Namespace) -> None:
         # Does not need to be executed as a separate process, but causes this function
         # to be called _after_ starting API and GUI. It finishes immediately
         browser_future = executor.submit(
-            webbrowser.open, f"http://localhost:{args.gui_port}/#token={token}"
+            webbrowser.open, f"http://{args.host}:{args.gui_port}/#token={token}"
         )
         try:
             browser_future.result()

--- a/src/fmu_settings_cli/api_server.py
+++ b/src/fmu_settings_cli/api_server.py
@@ -4,13 +4,15 @@ import sys
 
 from fmu_settings_api import run_server
 
+from .constants import API_PORT, GUI_PORT, HOST
+
 
 def start_api_server(
     token: str,
-    host: str = "127.0.0.1",
-    port: int = 8001,
-    frontend_host: str = "localhost",
-    frontend_port: int = 8000,
+    host: str = HOST,
+    port: int = API_PORT,
+    frontend_host: str = HOST,
+    frontend_port: int = GUI_PORT,
 ) -> None:
     """Starts the fmu-settings-api server.
 

--- a/src/fmu_settings_cli/constants.py
+++ b/src/fmu_settings_cli/constants.py
@@ -1,0 +1,5 @@
+"""Contains constants used between modules."""
+
+HOST: str = "localhost"
+API_PORT: int = 8001
+GUI_PORT: int = 8000

--- a/src/fmu_settings_cli/gui_server.py
+++ b/src/fmu_settings_cli/gui_server.py
@@ -4,11 +4,13 @@ import sys
 
 from fmu_settings_gui import run_server
 
+from .constants import GUI_PORT, HOST
+
 
 def start_gui_server(
     token: str,
-    host: str = "127.0.0.1",
-    port: int = 8000,
+    host: str = HOST,
+    port: int = GUI_PORT,
 ) -> None:
     """Starts the fmu-settings-api server.
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -97,7 +97,7 @@ def test_start_api_and_gui_processes(default_args: argparse.Namespace) -> None:
         )
         mock_executor_instance.submit.assert_any_call(
             mock_webbrowser_open,
-            f"http://localhost:{default_args.gui_port}/#token={token}",
+            f"http://{default_args.host}:{default_args.gui_port}/#token={token}",
         )
 
         mock_browser_future.result.assert_called_once()


### PR DESCRIPTION
Resolves #14 

Moves these values to constants to be more easily consistent. Also fixes a bug in the URL `webbrowser.open` opens.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
