### PR TITLE
ENH: Allow printing token in API mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ fmu-settings api
 It is also possible to specify the port and if the API should be reloaded, as
 in during development.
 
+## Starting the API only
+
 ```bash
 fmu-settings api --port 8001
 ```
@@ -48,6 +50,22 @@ export FMU_SETTINGS_PRINT_TOKEN=true
 # or
 FMU_SETTINGS_PRINT_TOKEN=true fmu-settings api --gui-port 5173
 ```
+
+It's also possible to print the full URL a user would be directed to with a
+similar URL flag and environment variable.
+
+```bash
+fmu-settings api --gui-port 5173 --print-url
+# or
+export FMU_SETTINGS_PRINT_URL=true
+# or
+FMU_SETTINGS_PRINT_URL=true fmu-settings api --gui-port 5173
+```
+
+Note that these additional flags are intended for development so they _only_ work
+with `fmu-settings api` subcommand.
+
+## Starting the GUI only
 
 You can similarly start the GUI server:
 


### PR DESCRIPTION
Resolves #16

Added both the token and URL flags and environment variables.

## Checklist

- [ ] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=<packagename> --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
