### PR TITLE
ENH: Poll processes and fail gracefully

### DIFF
--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -1,13 +1,14 @@
 """The main entry point for fmu-settings-cli."""
 
 import argparse
+import contextlib
 import hashlib
 import os
 import secrets
 import signal
 import sys
 import webbrowser
-from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures import ProcessPoolExecutor, as_completed
 
 from .api_server import start_api_server
 from .constants import API_PORT, GUI_PORT, HOST
@@ -132,6 +133,7 @@ def generate_auth_token() -> str:
 def init_worker() -> None:
     """Initializer to ignore signal interrupts on workers."""
     signal.signal(signal.SIGINT, signal.SIG_IGN)
+    signal.signal(signal.SIGTERM, signal.SIG_IGN)
 
 
 def create_authorized_url(token: str, host: str, gui_port: int) -> str:
@@ -147,37 +149,97 @@ def start_api_and_gui(token: str, args: argparse.Namespace) -> None:
         args: The arguments taken in from invocation
     """
     with ProcessPoolExecutor(max_workers=3, initializer=init_worker) as executor:
-        api_future = executor.submit(
-            start_api_server,
-            token,
-            host=args.host,
-            port=args.api_port,
-            frontend_host=args.host,
-            frontend_port=args.gui_port,
-            reload=args.reload,
-        )
-        gui_future = executor.submit(
-            start_gui_server,
-            token,
-            host=args.host,
-            port=args.gui_port,
-        )
-        # Does not need to be executed as a separate process, but causes this function
-        # to be called _after_ starting API and GUI. It finishes immediately
-        browser_future = executor.submit(
-            webbrowser.open, create_authorized_url(token, args.host, args.gui_port)
-        )
         try:
+            server_futures = {
+                "api": executor.submit(
+                    start_api_server,
+                    token,
+                    host=args.host,
+                    port=args.api_port,
+                    frontend_host=args.host,
+                    frontend_port=args.gui_port,
+                    reload=args.reload,
+                ),
+                "gui": executor.submit(
+                    start_gui_server,
+                    token,
+                    host=args.host,
+                    port=args.gui_port,
+                ),
+            }
+
+            # Does not need to be executed as a separate process, but causes this
+            # function to be called _after_ starting API and GUI. It finishes
+            # immediately.
+            browser_future = executor.submit(
+                webbrowser.open,
+                create_authorized_url(token, args.host, args.gui_port),
+            )
             browser_future.result()
-            print("FMU Settings is running. Press CTRL+C to quit")
-            # These block
-            api_future.result()
-            gui_future.result()
+
+            is_start_up = True
+            while True:
+                try:
+                    # Check once a half second if either the GUI or API process have
+                    # completed. This will typically mean crashed or otherwise failed.
+                    completed_future = next(
+                        as_completed(server_futures.values(), timeout=0.5)
+                    )
+                    try:
+                        service = next(
+                            name
+                            for name, f in server_futures.items()
+                            if f is completed_future
+                        ).upper()
+                        completed_future.result()
+                        print(
+                            f"Error: {service} unexpectedly exited. Please report this "
+                            "as a bug",
+                            file=sys.stderr,
+                        )
+                    except SystemExit as e:
+                        # If a port is in use, uvicorn will raise a SystemExit as this
+                        # is a fatal error. Unfortunately the exact message is emitted
+                        # as an ERROR log statement, not inside the exception itself.
+                        required_port = (
+                            args.gui_port if service == "GUI" else args.api_port
+                        )
+                        print(
+                            f"Error: {service} exited with exit code {e}. Usually this "
+                            "means that another application is already using port "
+                            f"{required_port}.",
+                            file=sys.stderr,
+                        )
+                    except Exception as e:
+                        # This is the exception raised by start_[api, gui]_server
+                        print(f"Error: {service} failed with: {e}", file=sys.stderr)
+                    break
+                except Exception:
+                    # This is the valid case, where the server future has not completed
+                    # within the 0.5 second timeout, and so raises a TimeoutError. But
+                    # grab all exceptions more broadly.
+                    if is_start_up:
+                        # Defer this message until we are certain GUI/API have started
+                        # without initial errors.
+                        print("FMU Settings is running. Press CTRL+C to quit")
+                        is_start_up = False
+                    continue
+
         except KeyboardInterrupt:
             print("\nShutting down FMU Settings...")
-            api_future.cancel()
-            gui_future.cancel()
-            executor.shutdown(wait=True)
+        finally:
+            for future in server_futures.values():
+                future.cancel()
+
+            # Uses the internal pid->process mapping. The executor API does not offer a
+            # way to retrieve this information, oddly. There is a small possibility this
+            # breaks in a future version of Python, although it is unlikely as it would
+            # disrupt a great deal of CPython code.
+            for process in executor._processes.values():
+                with contextlib.suppress(Exception):
+                    process.terminate()
+
+            executor.shutdown(wait=False, cancel_futures=True)
 
 
 def main(test_args: list[str] | None = None) -> None:

--- a/src/fmu_settings_cli/api_server.py
+++ b/src/fmu_settings_cli/api_server.py
@@ -1,13 +1,11 @@
 """Functionality to start the API server."""
 
-import sys
-
 from fmu_settings_api import run_server
 
 from .constants import API_PORT, GUI_PORT, HOST
 
 
-def start_api_server(  # noqa PLR0913
+def start_api_server(  # noqa: PLR0913
     token: str,
     host: str = HOST,
     port: int = API_PORT,
@@ -36,5 +34,4 @@ def start_api_server(  # noqa PLR0913
             reload=reload,
         )
     except Exception as e:
-        print(f"Could not start API server: {e}")
-        sys.exit(1)
+        raise RuntimeError(f"Could not start API server: {e}") from e

--- a/src/fmu_settings_cli/constants.py
+++ b/src/fmu_settings_cli/constants.py
@@ -3,3 +3,6 @@
 HOST: str = "localhost"
 API_PORT: int = 8001
 GUI_PORT: int = 8000
+
+APP_REG_PORTS: list[int] = [5173, 3000, 8000]
+"""These are ports that are known to the Azure App Registration."""

--- a/src/fmu_settings_cli/gui_server.py
+++ b/src/fmu_settings_cli/gui_server.py
@@ -1,10 +1,8 @@
 """Functionality to start the GUI server."""
 
-import sys
-
 from fmu_settings_gui import run_server
 
-from .constants import GUI_PORT, HOST
+from .constants import APP_REG_PORTS, GUI_PORT, HOST
 
 
 def start_gui_server(
@@ -12,16 +10,25 @@ def start_gui_server(
     host: str = HOST,
     port: int = GUI_PORT,
 ) -> None:
-    """Starts the fmu-settings-api server.
+    """Starts the fmu-settings-gui server.
+
+    If the port for the gui server is not one registered in the Azure App Registration,
+    the application will exit.
 
     Args:
         token: The authentication token the GUI uses
         host: The host to bind the server to
         port: The port to run the server on
     """
+    if port not in APP_REG_PORTS:
+        known_ports_str = ", ".join(str(i) for i in APP_REG_PORTS)
+        raise ValueError(
+            f"Port {port} is not known by the Azure App registration. "
+            f"Use one of {known_ports_str}."
+        )
+
     try:
         print(f"Starting FMU Settings GUI server on {host}:{port}...")
         run_server(host, port)
     except Exception as e:
-        print(f"Could not start GUI server: {e}")
-        sys.exit(1)
+        raise RuntimeError(f"Could not start GUI server: {e}") from e

--- a/tests/test_start_api_server.py
+++ b/tests/test_start_api_server.py
@@ -1,7 +1,8 @@
 """Tests for api_server.py."""
 
-import socket
 from unittest.mock import patch
+
+import pytest
 
 from fmu_settings_cli.__main__ import generate_auth_token
 from fmu_settings_cli.api_server import start_api_server
@@ -20,10 +21,9 @@ def test_start_api_server_fails() -> None:
     token = generate_auth_token()
     with (
         patch(
-            "fmu_settings_cli.api_server.run_server", side_effect=socket.error
+            "fmu_settings_cli.api_server.run_server", side_effect=OSError("fail")
         ) as mock_run_server,
-        patch("fmu_settings_cli.api_server.sys.exit") as mock_sys_exit,
+        pytest.raises(RuntimeError, match="Could not start API server: fail"),
     ):
         start_api_server(token)
         mock_run_server.assert_called_once()
-        mock_sys_exit.assert_called_once()

--- a/tests/test_start_gui_server.py
+++ b/tests/test_start_gui_server.py
@@ -1,29 +1,44 @@
 """Tests for gui_server.py."""
 
-import socket
 from unittest.mock import patch
+
+import pytest
+from pytest import CaptureFixture
 
 from fmu_settings_cli.__main__ import generate_auth_token
 from fmu_settings_cli.gui_server import start_gui_server
 
 
 def test_start_gui_server() -> None:
-    """Tests that start_api_server calls as expected."""
+    """Tests that start_gui_server calls as expected."""
     token = generate_auth_token()
     with patch("fmu_settings_cli.gui_server.run_server") as mock_run_server:
         start_gui_server(token)
         mock_run_server.assert_called_once()
 
 
-def test_start_api_server_fails() -> None:
-    """Tests that start_api_server failing raises an exception."""
+def test_start_gui_server_fails() -> None:
+    """Tests that start_gui_server failing raises an exception."""
     token = generate_auth_token()
     with (
         patch(
-            "fmu_settings_cli.gui_server.run_server", side_effect=socket.error
+            "fmu_settings_cli.gui_server.run_server", side_effect=OSError("fail")
         ) as mock_run_server,
-        patch("fmu_settings_cli.gui_server.sys.exit") as mock_sys_exit,
+        pytest.raises(RuntimeError, match="Could not start GUI server: fail"),
     ):
         start_gui_server(token)
         mock_run_server.assert_called_once()
-        mock_sys_exit.assert_called_once()
+
+
+def test_starting_gui_server_with_unknown_azure_port_exits(
+    capsys: CaptureFixture[str],
+) -> None:
+    """Tests that starting the gui server with an unknown port exits.
+
+    This is due to the gui server needing to use particular ports to authenticate with
+    Azure/SSO.
+    """
+    token = generate_auth_token()
+    bad_port = 1234
+    with pytest.raises(ValueError, match=f"Port {bad_port} is not known"):
+        start_gui_server(token, port=bad_port)


### PR DESCRIPTION
Resolves #27, and part of #26

Next PR will check ports before attempting to starts processes, as a more informative error message can be given that way.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
