### PR TITLE
ENH: Improve 'fmu init' error handling

### DIFF
--- a/src/fmu_settings_cli/prints.py
+++ b/src/fmu_settings_cli/prints.py
@@ -63,6 +63,39 @@ def validation_error(
         print(f"  [cyan]→[/cyan] {suggestion}", file=sys.stderr)
 
 
+def validation_warning(
+    e: ValidationError,
+    message: str = "Validation failed",
+    reason: str | None = None,
+    suggestion: str | None = None,
+) -> None:
+    """Prints warning messages specifically for Pydantic validation errors.
+
+    Args:
+        e: ValidationError raised by Pydantic.
+        message: General message to present as the error.
+        reason: Optional reason/explanation for the error
+        suggestion: Optional suggestion or additional info after the reason.
+    """
+    errors_text = []
+
+    for error in e.errors():
+        field = " → ".join(str(loc) for loc in error["loc"])
+        msg = error["msg"]
+        errors_text.append(f"[yellow]→[/yellow] [bold]{field}[/bold]: {msg}")
+
+    print("[bold dark_orange]Warning[/bold dark_orange]:", message, file=sys.stderr)
+
+    if reason:
+        print(f"  [dim]Reason:[/dim] {reason}", file=sys.stderr)
+
+    for error_line in errors_text:
+        print(f"  {error_line}", file=sys.stderr)
+
+    if suggestion:
+        print(f"  [cyan]→[/cyan] {suggestion}", file=sys.stderr)
+
+
 def success(
     *content: Any,
     reason: str | None = None,
@@ -123,10 +156,15 @@ def warning(
         suggestion: Optional suggestion or additional info after the reason
         **kwargs: Additional arguments to past to console.print().
     """
-    print("[bold dark_orange]Warning[/bold dark_orange]:", *content, **kwargs)
+    print(
+        "[bold dark_orange]Warning[/bold dark_orange]:",
+        *content,
+        **kwargs,
+        file=sys.stderr,
+    )
 
     if reason:
-        print(f"  [dim]Reason:[/dim] {reason}")
+        print(f"  [dim]Reason:[/dim] {reason}", file=sys.stderr)
 
     if suggestion:
-        print(f"  [cyan]→[/cyan] {suggestion}")
+        print(f"  [cyan]→[/cyan] {suggestion}", file=sys.stderr)

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -10,10 +10,23 @@ import pytest
 import yaml
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
 from fmu.settings import find_nearest_fmu_directory
+from pydantic import ValidationError
 from pytest import CaptureFixture
 
 from fmu_settings_cli.__main__ import main
 from fmu_settings_cli.init.main import REQUIRED_FMU_PROJECT_SUBDIRS, is_fmu_project
+
+
+def normalize_capsys(capsys: CaptureFixture[str]) -> tuple[str, str]:
+    """Returns stdout and stderr outputs into a flattened string.
+
+    Returns:
+        Tuple of stdout, stderr normalized strings.
+    """
+    captured = capsys.readouterr()
+    stdout = captured.out.replace("\n", " ").replace("  ", " ")
+    stderr = captured.err.replace("\n", " ").replace("  ", " ")
+    return stdout, stderr
 
 
 @pytest.mark.parametrize(
@@ -36,10 +49,10 @@ def test_is_fmu_project(
 
 
 def test_init_creates_user_fmu_if_not_exist(
-    tmp_path: Path, capsys: CaptureFixture[str]
+    in_tmp_path: Path, capsys: CaptureFixture[str]
 ) -> None:
     """Tests that 'fmu init' creates a user .fmu/ dir."""
-    home = tmp_path / "user"
+    home = in_tmp_path / "user"
     home.mkdir()
 
     with (
@@ -49,18 +62,17 @@ def test_init_creates_user_fmu_if_not_exist(
     ):
         main()
 
-    captured = capsys.readouterr()
-    stderr = captured.err.replace("\n", " ").replace("  ", " ")
+    stdout, stderr = normalize_capsys(capsys)
     assert "does not appear to be an FMU project" in stderr
     assert "ert" in stderr
     assert (home / ".fmu").exists()
 
 
 def test_init_creates_user_fmu_if_exist(
-    tmp_path: Path, capsys: CaptureFixture[str]
+    in_tmp_path: Path, capsys: CaptureFixture[str]
 ) -> None:
     """Tests that 'fmu init' does not fail creating a user .fmu/ dir if it exists."""
-    home = tmp_path / "user"
+    home = in_tmp_path / "user"
     home.mkdir()
     (home / ".fmu").mkdir()
 
@@ -71,15 +83,14 @@ def test_init_creates_user_fmu_if_exist(
     ):
         main()
 
-    captured = capsys.readouterr()
-    stderr = captured.err.replace("\n", " ").replace("  ", " ")
+    stdout, stderr = normalize_capsys(capsys)
     assert "does not appear to be an FMU project" in stderr
     assert "ert" in stderr
     assert (home / ".fmu").exists()
 
 
 def test_init_checks_if_fmu_dir_fails(
-    tmp_path: Path, capsys: CaptureFixture[str]
+    in_tmp_path: Path, capsys: CaptureFixture[str]
 ) -> None:
     """Tests that 'fmu init' checks if the directory has required subdirectories."""
     with (
@@ -88,13 +99,14 @@ def test_init_checks_if_fmu_dir_fails(
     ):
         main()
 
-    captured = capsys.readouterr()
-    stderr = captured.err.replace("\n", " ")
+    stdout, stderr = normalize_capsys(capsys)
     assert "does not appear to be an FMU project" in stderr
     assert "ert" in stderr
 
 
-def test_init_checks_if_fmu_dir_passes(in_tmp_path: Path) -> None:
+def test_init_checks_if_fmu_dir_passes(
+    in_tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
     """Tests that 'fmu init' checks if the directory has required subdirectories."""
     for dir_ in REQUIRED_FMU_PROJECT_SUBDIRS:
         (in_tmp_path / dir_).mkdir(parents=True, exist_ok=True)
@@ -105,10 +117,15 @@ def test_init_checks_if_fmu_dir_passes(in_tmp_path: Path) -> None:
         pytest.raises(SystemExit, match="0"),
     ):
         main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Success: All done!" in stdout
     assert fmu_dir.exists() is True
 
 
-def test_init_does_not_check_if_fmu_dir_is_forced(in_tmp_path: Path) -> None:
+def test_init_does_not_check_if_fmu_dir_is_forced(
+    in_tmp_path: Path, capsys: CaptureFixture[str]
+) -> None:
     """Tests that 'fmu init --force' doesn't check if the dir has required subdirs."""
     fmu_dir = in_tmp_path / ".fmu"
     assert fmu_dir.exists() is False
@@ -117,6 +134,7 @@ def test_init_does_not_check_if_fmu_dir_is_forced(in_tmp_path: Path) -> None:
         pytest.raises(SystemExit, match="0"),
     ):
         main()
+    stdout, stderr = normalize_capsys(capsys)
     assert fmu_dir.exists() is True
 
 
@@ -134,7 +152,9 @@ def test_init_looks_for_global_config(in_fmu_project: Path) -> None:
 
 
 def test_init_adds_global_variables_without_masterdata(
-    in_fmu_project: Path, global_variables_without_masterdata: dict[str, Any]
+    in_fmu_project: Path,
+    global_variables_without_masterdata: dict[str, Any],
+    capsys: CaptureFixture[str],
 ) -> None:
     """Tests that 'fmu init' fails creating a .fmu if the config has no masterdata."""
     tmp_path = in_fmu_project
@@ -147,17 +167,29 @@ def test_init_adds_global_variables_without_masterdata(
 
     with (
         patch.object(sys, "argv", ["fmu", "init"]),
-        pytest.raises(SystemExit, match="1"),
+        pytest.raises(SystemExit, match="0"),
     ):
         main()
 
-    with pytest.raises(FileNotFoundError):
-        find_nearest_fmu_directory()
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Warning: Unable to import masterdata" in stderr
+    assert "Reason: Validation of the global config/global variables failed." in stderr
+    assert "access: Field required" in stderr
+    assert "masterdata: Field required" in stderr
+    assert "model: Field required" in stderr
+    assert "Success: All done!" in stdout
+
+    fmu_dir = find_nearest_fmu_directory()
+    fmu_dir_cfg = fmu_dir.config.load()
+    assert fmu_dir_cfg.masterdata is None
+    assert fmu_dir_cfg.access is None
+    assert fmu_dir_cfg.model is None
 
 
 def test_init_adds_global_variables_with_masterdata(
     in_fmu_project: Path,
     generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+    capsys: CaptureFixture[str],
 ) -> None:
     """Tests that 'fmu init' adds masterdata if it does exist."""
     tmp_path = in_fmu_project
@@ -176,6 +208,11 @@ def test_init_adds_global_variables_with_masterdata(
         pytest.raises(SystemExit, match="0"),
     ):
         main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Success: Successfully imported masterdata" in stdout
+    assert "Success: All done!" in stdout
+
     fmu_dir = find_nearest_fmu_directory()
     fmu_dir_cfg = fmu_dir.config.load()
     assert fmu_dir_cfg.masterdata == valid_global_cfg.masterdata
@@ -186,6 +223,7 @@ def test_init_adds_global_variables_with_masterdata(
 def test_init_skips_adding_global_variables_with_masterdata(
     in_fmu_project: Path,
     generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+    capsys: CaptureFixture[str],
 ) -> None:
     """Tests that 'fmu init' skips adding masterdata with skip flag."""
     tmp_path = in_fmu_project
@@ -205,6 +243,9 @@ def test_init_skips_adding_global_variables_with_masterdata(
     ):
         main()
 
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Success: All done!" in stdout
+
     fmu_dir = find_nearest_fmu_directory()
     fmu_dir_cfg = fmu_dir.config.load()
     assert fmu_dir_cfg.masterdata is None
@@ -217,7 +258,7 @@ def test_init_raises_when_import_drogon_masterdata(
     global_variables_with_masterdata: dict[str, Any],
     capsys: CaptureFixture[str],
 ) -> None:
-    """Tests that 'fmu init' fails when importing Drogon masterdata."""
+    """Tests that 'fmu init' warns when importing Drogon masterdata."""
     tmp_path = in_fmu_project
 
     fmuconfig_out = tmp_path / "fmuconfig/output"
@@ -229,17 +270,20 @@ def test_init_raises_when_import_drogon_masterdata(
 
     with (
         patch.object(sys, "argv", ["fmu", "init"]),
-        pytest.raises(SystemExit, match="1"),
+        pytest.raises(SystemExit, match="0"),
     ):
         main()
 
-    captured = capsys.readouterr()
-    stderr = captured.err.replace("\n", " ").replace("  ", " ")
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Warning: Unable to import masterdata" in stderr
     assert "Reason: Invalid name in 'model': Drogon" in stderr
+    assert "Success: All done!" in stdout
 
 
 def test_init_skips_raising_when_import_drogon_masterdata_with_skip(
-    in_fmu_project: Path, global_variables_with_masterdata: dict[str, Any]
+    in_fmu_project: Path,
+    global_variables_with_masterdata: dict[str, Any],
+    capsys: CaptureFixture[str],
 ) -> None:
     """Tests that 'fmu init' skips raising on Drogon masterdata with skip flag."""
     tmp_path = in_fmu_project
@@ -257,8 +301,99 @@ def test_init_skips_raising_when_import_drogon_masterdata_with_skip(
         pytest.raises(SystemExit, match="0"),
     ):
         main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    # _not_ in
+    assert "Reason: Invalid name in 'model': Drogon" not in stderr
+    assert "Success: All done!" in stdout
+
     fmu_dir = find_nearest_fmu_directory()
     fmu_dir_cfg = fmu_dir.config.load()
     assert fmu_dir_cfg.masterdata is None
     assert fmu_dir_cfg.access is None
     assert fmu_dir_cfg.model is None
+
+
+def test_init_fmu_dir_exists_error(
+    in_fmu_project: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    """Tests that .fmu already existing gives error."""
+    fmu_dir = in_fmu_project / ".fmu"
+    fmu_dir.mkdir()
+    with (
+        patch.object(sys, "argv", ["fmu", "init", "--skip-config-import"]),
+        pytest.raises(SystemExit, match="1"),
+    ):
+        main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Error: Unable to create .fmu directory" in stderr
+    assert ".fmu already exists" in stderr
+    assert "You do not need to initialize a .fmu in this directory." in stderr
+    assert "Aborted." in stderr
+
+
+def test_init_fmu_dir_no_permissions_error(
+    in_fmu_project: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    """Tests that lacking permissions to create .fmu gives error."""
+    with (
+        patch.object(sys, "argv", ["fmu", "init", "--skip-config-import"]),
+        pytest.raises(SystemExit, match="1"),
+        patch(
+            "fmu_settings_cli.init.main.init_fmu_directory", side_effect=PermissionError
+        ),
+    ):
+        main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Error: Unable to create .fmu directory" in stderr
+    assert "lacking permissions to create" in stderr
+    assert "Aborted." in stderr
+
+
+def test_init_fmu_dir_validation_error(
+    in_fmu_project: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    """Tests that validation error when creating .fmu is caught.
+
+    This should never happen unless there's a race condition.
+    """
+    with (
+        patch.object(sys, "argv", ["fmu", "init", "--skip-config-import"]),
+        pytest.raises(SystemExit, match="1"),
+        patch(
+            "fmu_settings_cli.init.main.init_fmu_directory",
+            side_effect=ValidationError("Foo", []),
+        ),
+    ):
+        main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Error: Unable to create .fmu directory" in stderr
+    assert "Aborted." in stderr
+
+
+def test_init_fmu_dir_some_error(
+    in_fmu_project: Path,
+    capsys: CaptureFixture[str],
+) -> None:
+    """Tests that .fmu already existing gives error."""
+    with (
+        patch.object(sys, "argv", ["fmu", "init", "--skip-config-import"]),
+        pytest.raises(SystemExit, match="1"),
+        patch(
+            "fmu_settings_cli.init.main.init_fmu_directory",
+            side_effect=ValueError("Foo"),
+        ),
+    ):
+        main()
+
+    stdout, stderr = normalize_capsys(capsys)
+    assert "Error: Unable to create .fmu directory" in stderr
+    assert "Reason: Foo" in stderr
+    assert "Please report this as a bug" in stderr
+    assert "Aborted." in stderr


### PR DESCRIPTION
Resolves #37 
Resolves #40

The 'prints' module needs some work and tests, but it's a bit complicated by using Rich's `print`, so a bit duplicated. Will come in a PR next week.

How it looks under a few different conditions. Anything that should be different?

## .fmu already exists

<img width="452" height="62" alt="Screenshot 2025-10-17 at 09 39 43" src="https://github.com/user-attachments/assets/02e6bea5-94c0-4409-a695-28aac2eec38e" />

## Doesn't seem to be a valid .fmu dir (ert/ missing)

<img width="673" height="133" alt="Screenshot 2025-10-17 at 09 40 17" src="https://github.com/user-attachments/assets/71fe21df-873a-4382-92b9-369945621c9a" />

## Invalid data in global config/variables (Drogon)

<img width="683" height="89" alt="Screenshot 2025-10-17 at 09 40 50" src="https://github.com/user-attachments/assets/be288f91-5886-4a41-8af6-0f22201de106" />

## Missing masterdata fields (according to Pydantic)

<img width="692" height="130" alt="Screenshot 2025-10-17 at 09 41 32" src="https://github.com/user-attachments/assets/5acca39e-c2e5-4777-a72d-680347cd2b4e" />

## Successful created _and_ imported master data from global config

<img width="508" height="36" alt="Screenshot 2025-10-17 at 09 41 49" src="https://github.com/user-attachments/assets/81ae659c-ab41-4ca5-bb55-caacb25fc4e0" />

## Success, did not detect global config/variables

<img width="508" height="32" alt="Screenshot 2025-10-17 at 09 39 57" src="https://github.com/user-attachments/assets/b73b89f9-92ad-443b-a0f6-016ed4fb5970" />

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
