### PR TITLE
ENH: Add 'fmu sync'

### DIFF
--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -4,6 +4,7 @@ import typer
 
 from .init import init_cmd
 from .settings.cli import settings_app
+from .sync import sync_cmd
 
 app = typer.Typer(
     name="fmu",
@@ -13,6 +14,7 @@ app = typer.Typer(
 )
 
 app.add_typer(init_cmd, name="init")
+app.add_typer(sync_cmd, name="sync")
 app.add_typer(settings_app, name="settings")
 
 

--- a/src/fmu_settings_cli/sync/__init__.py
+++ b/src/fmu_settings_cli/sync/__init__.py
@@ -1,0 +1,5 @@
+"""The 'sync' command."""
+
+from .cli import sync_cmd
+
+__all__ = ["sync_cmd"]

--- a/src/fmu_settings_cli/sync/cli.py
+++ b/src/fmu_settings_cli/sync/cli.py
@@ -1,0 +1,110 @@
+"""The 'sync' command."""
+
+from pathlib import Path
+from typing import Annotated
+
+import typer
+from fmu.settings import find_nearest_fmu_directory, get_fmu_directory
+from pydantic import ValidationError
+
+from fmu_settings_cli.prints import (
+    error,
+    success,
+    validation_error,
+    warning,
+)
+
+from .model_diff import display_model_diff, get_model_diff
+
+sync_cmd = typer.Typer(
+    help=(
+        "Sync the settings and configuration of one FMU revision to another.\n\n"
+        "Currently this syncs only the .fmu configuration files."
+    ),
+    add_completion=True,
+)
+
+
+@sync_cmd.callback(invoke_without_command=True)
+def sync(
+    from_dir: Annotated[
+        Path,
+        typer.Option(
+            ...,
+            "--from",
+            "-f",
+            help="Path to FMU Setting revision to sync *from*",
+            default_factory=lambda: Path.cwd(),
+        ),
+    ],
+    ctx: typer.Context,
+    to_dir: Annotated[
+        Path,
+        typer.Option(
+            ...,
+            "--to",
+            "-t",
+            help="Path to FMU Setting revision to sync *to*",
+        ),
+    ],
+) -> None:
+    """The main entry point for the sync command."""
+    if ctx.invoked_subcommand is not None:  # pragma: no cover
+        return
+
+    try:
+        from_fmu = find_nearest_fmu_directory(from_dir)
+    except Exception as e:
+        error(
+            "Unable to find a known and valid FMU project to sync [bold]from[/bold]",
+            reason=str(e),
+            suggestion=(
+                "'cd' into the correct directory, or provide the path to the "
+                "revision you are sync [italic]from[/italic]"
+            ),
+        )
+        raise typer.Abort from e
+
+    try:
+        to_fmu = get_fmu_directory(to_dir)
+    except ValidationError as e:
+        validation_error(
+            e,
+            "Unable to load [bold]to[/bold] FMU Directory",
+            reason="Validation of its configuration failed.",
+            suggestion="You may have tried to sync to an incorrect directory path.",
+        )
+    except Exception as e:
+        error(
+            "Unable to find an FMU Settings configuration to sync [bold]to[/bold]",
+            reason=str(e),
+            suggestion=(
+                "Provide a path to the revision you are syncing [italic]to[/italic], "
+                "i.e. a master revision directory."
+            ),
+        )
+        raise typer.Abort from e
+
+    from_config = from_fmu.config.load()
+    to_config = to_fmu.config.load()
+
+    changes = get_model_diff(to_config, from_config)
+    if not changes:
+        success("No changes detected.")
+        raise typer.Exit(0)
+
+    display_model_diff(changes, to_config, from_config)
+
+    warning(
+        f"The above changes will be merged\n"
+        f"  [bold][cyan]→[/cyan] From[/bold]: {str(from_dir)}\n"
+        f"  [bold][cyan]→[/cyan] To[/bold]: {str(to_dir)}\n"
+    )
+    confirmed = typer.confirm("Merge these changes?")
+    if not confirmed:
+        raise typer.Abort
+
+    # TODO: Be more granular in updated. We don't want to update the 'created_at' or
+    # 'created_by', for example. But fine for an initial implementation.
+    to_fmu.update_config(from_config.model_dump())
+    success(f"All done! {from_dir} has been sync'd to {to_dir}.")

--- a/src/fmu_settings_cli/sync/model_diff.py
+++ b/src/fmu_settings_cli/sync/model_diff.py
@@ -1,0 +1,248 @@
+"""Utility functions for sync'ing."""
+
+from typing import Any, Final
+
+from pydantic import BaseModel
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+MAX_LIST_STR_LENGTH: Final[int] = 50
+MAX_VALUE_STR_LENGTH: Final[int] = 30
+IGNORED_FIELDS: Final[list[str]] = ["created_at", "created_by"]
+
+
+def get_model_diff(
+    old_model: BaseModel, new_model: BaseModel, prefix: str = ""
+) -> list[tuple[str, Any, Any]]:
+    """Recursively get differences between two Pydantic models."""
+    model_class = type(old_model)
+    if type(new_model) is not model_class:
+        raise ValueError(
+            "Models must be of the same type. Old model is of type "
+            f"'{old_model.__class__.__name__}', new model of type "
+            f"'{new_model.__class__.__name__}'."
+        )
+
+    changes: list[tuple[str, Any, Any]] = []
+
+    for field_name in model_class.model_fields:
+        if field_name in IGNORED_FIELDS:
+            continue
+
+        old_value = getattr(old_model, field_name)
+        new_value = getattr(new_model, field_name)
+
+        field_path = f"{prefix}.{field_name}" if prefix else field_name
+
+        if old_value is None and new_value is not None:
+            changes.append((field_path, None, new_value))
+        elif old_value is not None and new_value is None:
+            changes.append((field_path, old_value, None))
+        elif isinstance(old_value, BaseModel) and isinstance(new_value, BaseModel):
+            changes.extend(get_model_diff(old_value, new_value, field_path))
+        elif isinstance(old_value, list) and isinstance(new_value, list):
+            if old_value != new_value:
+                changes.append((field_path, old_value, new_value))
+        elif old_value != new_value:
+            changes.append((field_path, old_value, new_value))
+
+    return changes
+
+
+def format_simple_value(value: Any, max_length: int = MAX_VALUE_STR_LENGTH) -> str:
+    """Format a value for display, handling BaseModels specially."""
+    if value is None:
+        return "[dim italic]None[/dim italic]"
+
+    if isinstance(value, BaseModel):
+        value = type(value).__name__
+
+    str_val = str(value)
+    if len(str_val) > max_length:
+        return f"{str_val[:max_length]}..."
+    return str_val
+
+
+def is_list_of_models(value: Any) -> bool:
+    """Check if value is a list containing BaseModels."""
+    return (
+        isinstance(value, list)
+        and len(value) > 0
+        and all(isinstance(v, BaseModel) for v in value)
+    )
+
+
+def is_complex_change(old_val: Any, new_val: Any) -> bool:
+    """Determines if a change is complex.
+
+    Complex changes are displayed in a separate table.
+    """
+    if (
+        isinstance(new_val, BaseModel)
+        or isinstance(old_val, BaseModel)
+        or is_list_of_models(old_val)
+        or is_list_of_models(new_val)
+    ):
+        return True
+
+    # If one of the values is a list
+    if isinstance(old_val, list) or isinstance(new_val, list):
+        # And the other is None
+        if old_val is None or new_val is None:
+            return True
+
+        # Or, the string representation is too long
+        if (
+            len(str(old_val)) > MAX_LIST_STR_LENGTH
+            or len(str(new_val)) > MAX_LIST_STR_LENGTH
+        ):
+            return True
+
+    return False
+
+
+def add_model_to_panel_content(model: BaseModel, indent: int = 0) -> list[str]:
+    """Recursively build panel content line for a BaseModel."""
+    lines = []
+    indent_str = "  " * indent
+
+    for key, value in model.model_dump().items():
+        actual_value = getattr(model, key)
+
+        if isinstance(actual_value, BaseModel):
+            lines.append(
+                f"{indent_str}[bold]{key}:[/bold] "
+                f"[dim]{type(actual_value).__name__}[/dim]"
+            )
+            lines.extend(add_model_to_panel_content(actual_value, indent + 1))
+        elif is_list_of_models(actual_value):
+            lines.append(
+                f"{indent_str}[bold]{key}:[/bold] [dim]{len(actual_value)} items[/dim]"
+            )
+            for item in actual_value:
+                lines.append(f"{indent_str}  [dim]- {type(item).__name__}[/dim]")
+                lines.extend(add_model_to_panel_content(item, indent + 2))
+        elif isinstance(value, dict) and not isinstance(actual_value, BaseModel):
+            lines.append(f"{indent_str}[bold]{key}:[/bold]")
+            for k, v in value.items():
+                lines.append(f"{indent_str} [dim]{k}:[/dim] {v}")
+        else:
+            lines.append(f"{indent_str}[bold]{key}:[/bold] {value}")
+
+    return lines
+
+
+def render_basemodel_panel(
+    model: BaseModel, field_path: str, added: bool = True
+) -> Panel:
+    """Render a BaseModel as a Rich Panel."""
+    content_lines = add_model_to_panel_content(model)
+    content = "\n".join(content_lines)
+    color = "green" if added else "red"
+    action = "Added" if added else "Removed"
+    return Panel(
+        content,
+        title=f"[{color}] {action}: {field_path}[/{color}]",
+        border_style=color,
+        subtitle=f"[{color}]{type(model).__name__}[/{color}]",
+    )
+
+
+def add_list_to_panel_content(items: list[Any], indent: int = 0) -> list[str]:
+    """Build panel content for a list (of models or simple values)."""
+    lines = []
+    indent_str = "  " * indent
+
+    if is_list_of_models(items):
+        for item in items:
+            lines.append(f"{indent_str}[dim]- {type(item).__name__}[/dim]")
+            lines.extend(add_model_to_panel_content(item, indent + 1))
+    else:
+        for item in items:
+            lines.append(f"{indent_str}[dim]-[/dim] {item}")
+
+    return lines
+
+
+def render_list_panel(items: list[Any], field_path: str, added: bool = True) -> Panel:
+    """Render a list as a rich panel."""
+    content_lines = add_list_to_panel_content(items)
+    content = "\n".join(content_lines)
+    color = "green" if added else "red"
+    action = "Added" if added else "Removed"
+    return Panel(
+        content,
+        title=f"[{color}] {action}: {field_path}[/{color}]",
+        border_style=color,
+        subtitle=f"[{color}]{len(items)} items[/{color}]",
+    )
+
+
+def display_model_diff(
+    changes: list[tuple[str, Any, Any]], old_model: BaseModel, new_model: BaseModel
+) -> None:
+    """Display diff in table format."""
+    console = Console()
+    if not changes:
+        console.print("No changes detected.")
+        return
+
+    complex_changes = []
+
+    for field_path, old_val, new_val in changes:
+        if is_complex_change(old_val, new_val):
+            complex_changes.append((field_path, old_val, new_val))
+
+    table = Table(
+        title=f"Value Changes in {type(old_model).__name__}",
+        show_header=True,
+        header_style="bold",
+    )
+    table.add_column("Field", style="cyan", no_wrap=True)
+    table.add_column("Old Value", style="red")
+    table.add_column("New Value", style="green")
+
+    for field_path, old_val, new_val in changes:
+        table.add_row(
+            field_path, format_simple_value(old_val), format_simple_value(new_val)
+        )
+
+    console.print(table)
+    console.print()
+
+    if complex_changes:
+        table = Table(
+            title=f"Complex Changes in {type(old_model).__name__}",
+            show_header=True,
+            header_style="bold",
+        )
+        table.add_column("Field", style="cyan", no_wrap=True)
+        table.add_column("Change")
+        for field_path, old_val, new_val in complex_changes:
+            if old_val is None and isinstance(new_val, BaseModel):
+                panel = render_basemodel_panel(new_val, field_path, added=True)
+                table.add_row(field_path, panel)
+            elif isinstance(old_val, BaseModel) and new_val is None:
+                panel = render_basemodel_panel(old_val, field_path, added=False)
+                table.add_row(field_path, panel)
+            elif old_val is None and isinstance(new_val, list):
+                panel = render_list_panel(new_val, field_path, added=True)
+                table.add_row(field_path, panel)
+            elif isinstance(old_val, list) and new_val is None:
+                panel = render_list_panel(old_val, field_path, added=False)
+                table.add_row(field_path, panel)
+            elif isinstance(old_val, list) and isinstance(old_val, list):
+                panel_old = render_list_panel(
+                    old_val, f"{field_path} (old)", added=False
+                )
+                table.add_row(field_path, panel_old)
+                panel_new = render_list_panel(
+                    new_val, f"{field_path} (new)", added=True
+                )
+                table.add_row(field_path, panel_new)
+
+        console.print(table)
+
+    # Extra new line before prompt
+    console.print()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from fmu.datamodels.fmu_results.global_configuration import (
     Stratigraphy,
     StratigraphyElement,
 )
+from fmu.settings import ProjectFMUDirectory
+from fmu.settings._init import init_fmu_directory
 from pytest import MonkeyPatch
 
 from fmu_settings_cli.init.cli import REQUIRED_FMU_PROJECT_SUBDIRS
@@ -223,3 +225,22 @@ def generate_strict_valid_globalconfiguration() -> Callable[[], GlobalConfigurat
         )
 
     return _generate_cfg
+
+
+@pytest.fixture
+def two_fmu_revisions(
+    tmp_path: Path,
+    generate_strict_valid_globalconfiguration: Callable[[], GlobalConfiguration],
+) -> tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory]:
+    """Generates a dir with two user revisions with the same global configuration."""
+    project_a = tmp_path / "a"
+    project_b = tmp_path / "b"
+
+    fmu_dirs = []
+    global_config = generate_strict_valid_globalconfiguration()
+    for project in (project_a, project_b):
+        (project / "ert").mkdir(parents=True, exist_ok=True)
+        (project / "fmuconfig/input").mkdir(parents=True, exist_ok=True)
+        fmu_dirs.append(init_fmu_directory(project, global_config=global_config))
+
+    return tmp_path, fmu_dirs[0], fmu_dirs[1]

--- a/tests/test_sync/test_sync_cli.py
+++ b/tests/test_sync/test_sync_cli.py
@@ -1,0 +1,279 @@
+"""Tests for the 'fmu sync' commands."""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fmu.datamodels.fmu_results.fields import CountryItem
+from fmu.settings import ProjectFMUDirectory
+from pytest import MonkeyPatch
+from typer.testing import CliRunner
+
+from fmu_settings_cli.__main__ import app
+from fmu_settings_cli.sync.model_diff import IGNORED_FIELDS
+
+# ruff: noqa: PLR2004
+
+runner = CliRunner()
+
+
+def test_sync_cmd_with_help(patch_ensure_port: Generator[None]) -> None:
+    """Tests that 'fmu sync' emits help information."""
+    result = runner.invoke(app, ["sync", "--help"])
+
+    assert result.exit_code == 0
+    assert "Usage: fmu sync" in result.stdout
+    assert "Sync the settings and configuration" in result.stdout
+    assert "--from" in result.stdout
+    assert "--to" in result.stdout
+
+
+def test_sync_cmd_with_no_options() -> None:
+    """Tests that 'fmu sync' errors with no options."""
+    result = runner.invoke(app, ["sync"])
+    assert "Missing option '--to'" in result.stderr
+    assert result.exit_code == 2
+
+
+def test_sync_but_no_fmu_directory(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Tests that running 'fmu sync' with no FMU directory nearby issues an error."""
+    monkeypatch.chdir(tmp_path)
+    result = runner.invoke(app, ["sync", "--to", "foo"])
+    assert "Unable to find a known and valid FMU project" in result.stderr
+    assert "No .fmu directory found" in result.stderr
+    assert "'cd' into the correct directory" in result.stderr
+    assert "Abort" in result.stderr
+    assert result.exit_code == 1
+
+
+def test_sync_invalid_to_dir_config_json_raises_validation_error(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' displays a validation error if the target is invalid."""
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    # Make '--to' target config invalid
+    project_b.config.path.write_text("invalid")
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="y\n"
+    )
+
+    assert "Unable to find an FMU Settings configuration to sync to" in result.stderr
+    assert (
+        "Reason: Invalid JSON in resource file for 'ProjectConfigManager'"
+        in result.stderr
+    )
+    assert result.exit_code == 1
+
+
+def test_sync_invalid_to_dir_config_content_raises_validation_error(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' displays a validation error if the target is invalid."""
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    # Make '--to' target config invalid
+    project_b.config.path.write_text('{"invalid": 1}')
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="y\n"
+    )
+    assert "Unable to find an FMU Settings configuration to sync to" in result.stderr
+    assert (
+        "Reason: Invalid content in resource file for 'ProjectConfigManager"
+        in result.stderr
+    )
+    assert "validation errors" in result.stderr
+    assert result.exit_code == 1
+
+
+@pytest.mark.parametrize(
+    "from_flag, to_flag",
+    [("--from", "--to"), ("-f", "--to"), ("-f", "-t"), ("--from", "-t")],
+)
+def test_sync_from_no_changes(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    from_flag: str,
+    to_flag: str,
+) -> None:
+    """Tests that 'fmu sync' uses 'from'/'to' flags and emits no changes message.
+
+    Also sanity checks the short and long flags.
+    """
+    tmp_path, project_a, project_b = two_fmu_revisions
+    result = runner.invoke(
+        app,
+        [
+            "sync",
+            from_flag,
+            str(project_a.path.parent),
+            to_flag,
+            str(project_b.path.parent),
+        ],
+    )
+    assert "No changes detected" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_sync_no_changes_from_current_dir(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' detects nothing has changed from the current directory."""
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+    result = runner.invoke(app, ["sync", "--to", str(project_b.path.parent)])
+    assert "No changes detected" in result.stdout
+    assert result.exit_code == 0
+
+
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("created_at", datetime.now(UTC)),
+        ("created_by", "foo"),
+    ],
+)
+def test_sync_disregards_ignored_fields(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+    field: str,
+    value: Any,
+) -> None:
+    """Tests that 'fmu sync' does not see ignored fields as changes to sync."""
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    assert field in IGNORED_FIELDS
+    project_a.set_config_value(field, value)
+
+    result = runner.invoke(app, ["sync", "--to", str(project_b.path.parent)])
+    assert "No changes detected" in result.stdout
+    assert result.exit_code == 0
+
+
+def test_sync_finds_changed_value_field(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' displays and confirms a changed field.
+
+    No is selected.
+    """
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    project_a.set_config_value("model.name", "foo")
+
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="n\n"
+    )
+    assert "Value Changes in ProjectConfig" in result.stdout
+    assert "model.name" in result.stdout
+    assert "foo" in result.stdout
+    assert result.exit_code == 1
+
+    # Does not update it.
+    assert project_b.config.load().model.name == ""  # type: ignore[union-attr]
+
+
+def test_sync_finds_changed_value_field_and_saves_after_confirm(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' displays and confirms a changed value field.
+
+    Yes is selected.
+    """
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    project_a.set_config_value("model.name", "foo")
+
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="y\n"
+    )
+    assert "Value Changes in ProjectConfig" in result.stdout
+    assert "model.name" in result.stdout
+    assert "foo" in result.stdout
+    assert "Complex Changes" not in result.stdout  # Not in
+    assert "Success: All done!" in result.stdout
+    assert result.exit_code == 0
+
+    # Does update it.
+    assert project_b.config.load(force=True).model.name == "foo"  # type: ignore[union-attr]
+
+
+def test_sync_finds_changed_complex_field_and_saves_after_confirm(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' displays and confirms a changed complex (BaseModel) field.
+
+    Yes is selected.
+    """
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    project_b.set_config_value("masterdata", None)
+    assert project_b.config.load(force=True).masterdata is None
+
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="y\n"
+    )
+
+    assert "Value Changes in ProjectConfig" in result.stdout
+    assert "masterdata" in result.stdout
+    assert "None" in result.stdout
+    assert "Masterdata" in result.stdout
+
+    assert "Complex Changes" in result.stdout
+    assert "Added: masterdata" in result.stdout
+    assert "smda: Smda" in result.stdout
+    assert "Success: All done!" in result.stdout
+    assert result.exit_code == 0
+
+    assert (
+        project_b.config.load(force=True).masterdata
+        == project_a.config.load().masterdata
+    )
+
+
+def test_sync_finds_changed_list_and_saves_after_confirm(
+    two_fmu_revisions: tuple[Path, ProjectFMUDirectory, ProjectFMUDirectory],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    """Tests that 'fmu sync' detects and displays a changed list field correctly.
+
+    Yes is selected.
+    """
+    tmp_path, project_a, project_b = two_fmu_revisions
+    monkeypatch.chdir(project_a.path.parent)
+
+    uuid = uuid4()
+    country_item = CountryItem(identifier="Norway", uuid=uuid)
+    project_a.set_config_value("masterdata.smda.country", [country_item])
+    assert project_a.config.load(force=True).masterdata.smda.country[0] == country_item  # type: ignore[union-attr]
+
+    result = runner.invoke(
+        app, ["sync", "--to", str(project_b.path.parent)], input="y\n"
+    )
+
+    assert "Value Changes in ProjectConfig" in result.stdout
+    assert "masterdata.smda.country" in result.stdout
+    assert "[]" in result.stdout
+
+    assert "Complex Changes" in result.stdout
+    assert "Removed: masterdata.smda.country (old)" in result.stdout
+    assert "1 items" in result.stdout
+    assert "Added: masterdata.smda.country (new)" in result.stdout
+    assert "0 items" in result.stdout
+    assert result.exit_code == 0
+
+    assert project_b.config.load(force=True).masterdata.smda.country == [country_item]  # type: ignore[union-attr]

--- a/tests/test_sync/test_sync_model_diff.py
+++ b/tests/test_sync/test_sync_model_diff.py
@@ -1,0 +1,86 @@
+"""Tests for the 'fmu sync' model diffing."""
+
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from fmu_settings_cli.sync.model_diff import (
+    MAX_LIST_STR_LENGTH,
+    MAX_VALUE_STR_LENGTH,
+    format_simple_value,
+    get_model_diff,
+    is_complex_change,
+    is_list_of_models,
+)
+
+# ruff: noqa: PLR2004
+
+
+class A(BaseModel):
+    """Test model."""
+
+    a: int
+
+
+class B(BaseModel):
+    """Test model."""
+
+    a: int
+
+
+def test_model_diff_different_models() -> None:
+    """Returns if different models."""
+    with pytest.raises(ValueError, match="Models must be of the same type"):
+        get_model_diff(A(a=0), B(a=0))
+
+
+@pytest.mark.parametrize(
+    "old_val, new_val, expected",
+    [
+        (A(a=0), None, True),
+        (None, A(a=0), True),
+        ("foo", A(a=0), True),
+        (None, [A(a=0), A(a=0)], True),
+        ([A(a=0), A(a=0)], 1, True),
+        ([1, 2, 3], None, True),
+        (None, [1, 2, 3], True),
+        (["a"] * (MAX_LIST_STR_LENGTH + 1), ["a"], True),
+        (["supercalifragilisticexpialidocious" * 3], None, True),
+        ("foo", "bar", False),
+        ([], [], False),
+        (3, 4, False),
+    ],
+)
+def test_is_complex_change(old_val: Any, new_val: Any, expected: bool) -> None:
+    """Tests that complex changes are correctly found."""
+    assert is_complex_change(old_val, new_val) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ([A(a=0), {}], False),
+        ([], False),
+        (3, False),
+        (A(a=0), False),
+        ([A(a=0), B(a=0)], True),
+    ],
+)
+def test_is_list_of_models(value: Any, expected: bool) -> None:
+    """Tests that is_list_of_models detects correctly."""
+    assert is_list_of_models(value) is expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (None, "[dim italic]None[/dim italic]"),
+        (1, "1"),
+        (A(a=0), "A"),
+        ("a" * (MAX_VALUE_STR_LENGTH + 1), f"{'a' * MAX_VALUE_STR_LENGTH}..."),
+    ],
+)
+def test_format_simple_value(value: Any, expected: str) -> None:
+    """Tests format simple value works as expected."""
+    assert format_simple_value(value) == expected

--- a/uv.lock
+++ b/uv.lock
@@ -4,11 +4,11 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "annotated-doc"
-version = "0.0.2"
+version = "0.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c4/92/2974dba489541ed4af531d00a4df075bc3a455557d3b54fd6932c51c95cc/annotated_doc-0.0.2.tar.gz", hash = "sha256:f25664061aee278227abfaec5aeb398298be579b934758c16205d48e896e149c", size = 4452, upload-time = "2025-10-22T18:38:52.597Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/a6/dc46877b911e40c00d395771ea710d5e77b6de7bacd5fdcd78d70cc5a48f/annotated_doc-0.0.3.tar.gz", hash = "sha256:e18370014c70187422c33e945053ff4c286f453a984eba84d0dbfa0c935adeda", size = 5535, upload-time = "2025-10-24T14:57:10.718Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/ee/cc5109cdd46a6ccd3d923db3c5425383abe51b5c033647aad1b5e2452e82/annotated_doc-0.0.2-py3-none-any.whl", hash = "sha256:2188cb99e353fcb5c20f23b8bc6f5fa7c924b213fac733d4b44883f9edffa090", size = 4056, upload-time = "2025-10-22T18:38:51.24Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b7/cf592cb5de5cb3bade3357f8d2cf42bf103bbe39f459824b4939fd212911/annotated_doc-0.0.3-py3-none-any.whl", hash = "sha256:348ec6664a76f1fd3be81f43dffbee4c7e8ce931ba71ec67cc7f4ade7fbbb580", size = 5488, upload-time = "2025-10-24T14:57:09.462Z" },
 ]
 
 [[package]]
@@ -167,7 +167,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.120.0"
+version = "0.120.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -175,9 +175,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/0e/7f29e8f7219e4526747db182e1afb5a4b6abc3201768fb38d81fa2536241/fastapi-0.120.0.tar.gz", hash = "sha256:6ce2c1cfb7000ac14ffd8ddb2bc12e62d023a36c20ec3710d09d8e36fab177a0", size = 337603, upload-time = "2025-10-23T20:56:34.743Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/40/cc/28aff6e246ee85bd571b26e4a793b84d42700e3bdc3008c3d747eda7b06d/fastapi-0.120.1.tar.gz", hash = "sha256:b5c6217e9ddca6dfcf54c97986180d4a1955e10c693d74943fc5327700178bff", size = 337616, upload-time = "2025-10-27T17:53:42.954Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/60/7a639ceaba54aec4e1d5676498c568abc654b95762d456095b6cb529b1ca/fastapi-0.120.0-py3-none-any.whl", hash = "sha256:84009182e530c47648da2f07eb380b44b69889a4acfd9e9035ee4605c5cfc469", size = 108243, upload-time = "2025-10-23T20:56:33.281Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/bb/1a74dbe87e9a595bf63052c886dfef965dc5b91d149456a8301eb3d41ce2/fastapi-0.120.1-py3-none-any.whl", hash = "sha256:0e8a2c328e96c117272d8c794d3a97d205f753cc2e69dd7ee387b7488a75601f", size = 108254, upload-time = "2025-10-27T17:53:40.076Z" },
 ]
 
 [[package]]
@@ -206,7 +206,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.5.4"
+version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -215,9 +215,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fd/39/43eb27e140003e0ba831f7f449311199524704b5d016fa52004966c56557/fmu_settings-0.5.4.tar.gz", hash = "sha256:99415976fe75d8a516dde5099058412f6f846fc8e8ede89a6a029610d04f5128", size = 51465, upload-time = "2025-10-24T07:07:26.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/7a/cb8fdb529d4c8405372c45b1c394a8f73651c43d4df44655ab1cce12f692/fmu_settings-0.6.1.tar.gz", hash = "sha256:4de70d005ca8b53e01521d0718764054878ef32678d5de009df213488fb09e2e", size = 52615, upload-time = "2025-10-28T07:39:25.287Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/be/faa07021b7eb279b877d807b2c886d07b694b8b32cc9aad6f4cbb7f75537/fmu_settings-0.5.4-py3-none-any.whl", hash = "sha256:eaa59c9b2b912751e932015b150d7de43ee1d4d97c08705b4fae087e1ef9df33", size = 36196, upload-time = "2025-10-24T07:07:25.397Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/5b/3474881c6feffabefe7fa116261482c9298fa4acd56e34c98c13effcb3bf/fmu_settings-0.6.1-py3-none-any.whl", hash = "sha256:89936139934507db0c35d7713b8c9094ade30c85c0505e2e8cd05352e640dc12", size = 37417, upload-time = "2025-10-28T07:39:23.91Z" },
 ]
 
 [[package]]
@@ -730,15 +730,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "0.48.0"
+version = "0.49.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/a5/d6f429d43394057b67a6b5bbe6eae2f77a6bf7459d961fdb224bf206eee6/starlette-0.48.0.tar.gz", hash = "sha256:7e8cee469a8ab2352911528110ce9088fdc6a37d9876926e73da7ce4aa4c7a46", size = 2652949, upload-time = "2025-09-13T08:41:05.699Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/3f/507c21db33b66fb027a332f2cb3abbbe924cc3a79ced12f01ed8645955c9/starlette-0.49.1.tar.gz", hash = "sha256:481a43b71e24ed8c43b11ea02f5353d77840e01480881b8cb5a26b8cae64a8cb", size = 2654703, upload-time = "2025-10-28T17:34:10.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/be/72/2db2f49247d0a18b4f1bb9a5a39a0162869acf235f3a96418363947b3d46/starlette-0.48.0-py3-none-any.whl", hash = "sha256:0764ca97b097582558ecb498132ed0c7d942f233f365b86ba37770e026510659", size = 73736, upload-time = "2025-09-13T08:41:03.869Z" },
+    { url = "https://files.pythonhosted.org/packages/51/da/545b75d420bb23b5d494b0517757b351963e974e79933f01e05c929f20a6/starlette-0.49.1-py3-none-any.whl", hash = "sha256:d92ce9f07e4a3caa3ac13a79523bd18e3bc0042bb8ff2d759a8e7dd0e1859875", size = 74175, upload-time = "2025-10-28T17:34:09.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Resolves #47

Displays two types of diffs: simple value changes (fields), or complex model changes (i.e. `None` -> `Masterdata`). The red and the green try to match the standard `diff` color semantics, e.g. `diff <(echo "string1") <(echo "string2")`

Some examples of simple value changes

<img width="481" height="229" alt="Screenshot 2025-10-29 at 07 58 28" src="https://github.com/user-attachments/assets/e39deffc-d29c-44db-9587-51a65459ccf5" />

<img width="727" height="245" alt="Screenshot 2025-10-29 at 07 59 18" src="https://github.com/user-attachments/assets/ed0f7203-a5b7-4062-abdb-9b7125770ef4" />

<img width="485" height="228" alt="Screenshot 2025-10-29 at 07 59 50" src="https://github.com/user-attachments/assets/cbf53477-f043-43c3-830f-c4d062e23c84" />

Example of complex: it shows the simple field, and examples into the complex diff

<img width="498" height="852" alt="Screenshot 2025-10-29 at 07 57 26" src="https://github.com/user-attachments/assets/c40acece-32e6-4cf8-88bb-c61b2c9faeb5" />

Some test coverage is missing in model diff, because they are prints, and because currently not all conditions are entered into with the current project/global configuration.

## Checklist

- [x] Tests added (if not, comment why)
- [ ] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
