### PR TITLE
ENH: Create user .fmu/ on all commands

### DIFF
--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -1,16 +1,27 @@
 """The main entry point for fmu-settings-cli."""
 
+import contextlib
+
 import typer
+from fmu.settings._init import init_user_fmu_directory
 
 from .init import init_cmd
 from .settings.cli import settings_app
 from .sync import sync_cmd
+
+
+def init_user_fmu() -> None:
+    """Create a user .fmu/ whenever a command is run."""
+    with contextlib.suppress(FileExistsError):
+        init_user_fmu_directory()
+
 
 app = typer.Typer(
     name="fmu",
     help="FMU Settings - Manage your FMU project",
     add_completion=True,
     no_args_is_help=True,
+    callback=init_user_fmu,
 )
 
 app.add_typer(init_cmd, name="init")

--- a/src/fmu_settings_cli/init/cli.py
+++ b/src/fmu_settings_cli/init/cli.py
@@ -1,6 +1,5 @@
 """The 'init' command."""
 
-import contextlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Final
 
@@ -9,7 +8,7 @@ from fmu.settings._global_config import (
     InvalidGlobalConfigurationError,
     find_global_config,
 )
-from fmu.settings._init import init_fmu_directory, init_user_fmu_directory
+from fmu.settings._init import init_fmu_directory
 from pydantic import ValidationError
 from rich.table import Table
 
@@ -79,9 +78,6 @@ def init(
     """The main entry point for the init command."""
     if ctx.invoked_subcommand is not None:  # pragma: no cover
         return
-
-    with contextlib.suppress(FileExistsError):
-        init_user_fmu_directory()
 
     cwd = Path.cwd()
 

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -37,20 +37,6 @@ def test_is_fmu_project(
     assert is_fmu_project(in_tmp_path) == expected
 
 
-def test_init_creates_user_fmu_if_not_exist(in_tmp_path: Path) -> None:
-    """Tests that 'fmu init' creates a user .fmu/ dir."""
-    home = in_tmp_path / "user"
-    home.mkdir()
-
-    with patch("pathlib.Path.home", return_value=home):
-        result = runner.invoke(app, ["init"])
-
-    assert result.exit_code == 1
-    assert "does not appear to be an FMU project" in result.stderr
-    assert "ert" in result.stderr
-    assert (home / ".fmu").exists()
-
-
 def test_init_creates_user_fmu_if_exist(in_tmp_path: Path) -> None:
     """Tests that 'fmu init' does not fail creating a user .fmu/ dir if it exists."""
     home = in_tmp_path / "user"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,31 @@
+"""Tests 'fmu *' functionality."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from fmu_settings_cli.__main__ import app
+
+runner = CliRunner()
+
+
+@pytest.mark.parametrize(
+    "cmd",
+    [
+        ["init", "--help"],
+        ["settings", "--help"],
+        ["sync", "--help"],
+    ],
+)
+def test_cmds_create_user_fmu_if_not_exist(in_tmp_path: Path, cmd: list[str]) -> None:
+    """Tests that all 'fmu *' commands create a user .fmu/ dir."""
+    home = in_tmp_path / "user"
+    home.mkdir()
+
+    with patch("pathlib.Path.home", return_value=home):
+        result = runner.invoke(app, cmd)
+
+    assert result.exit_code == 0
+    assert (home / ".fmu").exists()


### PR DESCRIPTION
Resolves #48


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
