### PR TITLE
ENH: Display absolute paths for sync

### DIFF
--- a/src/fmu_settings_cli/sync/cli.py
+++ b/src/fmu_settings_cli/sync/cli.py
@@ -95,10 +95,13 @@ def sync(
 
     display_model_diff(changes, to_config, from_config)
 
+    from_dir_abs = from_dir.absolute()
+    to_dir_abs = to_dir.absolute()
+
     warning(
         f"The above changes will be merged\n"
-        f"  [bold][cyan]→[/cyan] From[/bold]: {str(from_dir)}\n"
-        f"  [bold][cyan]→[/cyan] To[/bold]: {str(to_dir)}\n"
+        f"  [bold][cyan]→[/cyan] From[/bold]: {str(from_dir_abs)}\n"
+        f"  [bold][cyan]→[/cyan] To[/bold]: {str(to_dir_abs)}\n"
     )
     confirmed = typer.confirm("Merge these changes?")
     if not confirmed:
@@ -107,4 +110,4 @@ def sync(
     # TODO: Be more granular in updated. We don't want to update the 'created_at' or
     # 'created_by', for example. But fine for an initial implementation.
     to_fmu.update_config(from_config.model_dump())
-    success(f"All done! {from_dir} has been sync'd to {to_dir}.")
+    success(f"All done! {from_dir_abs} has been sync'd to {to_dir_abs}.")

--- a/tests/test_sync/test_sync_cli.py
+++ b/tests/test_sync/test_sync_cli.py
@@ -204,6 +204,9 @@ def test_sync_finds_changed_value_field_and_saves_after_confirm(
     assert "foo" in result.stdout
     assert "Complex Changes" not in result.stdout  # Not in
     assert "Success: All done!" in result.stdout
+    # Full, absolute paths are used
+    assert str(project_a.path.parent.absolute()) in result.stdout.replace("\n", "")
+    assert str(project_b.path.parent.absolute()) in result.stdout.replace("\n", "")
     assert result.exit_code == 0
 
     # Does update it.


### PR DESCRIPTION
Resolves #52

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
