### PR TITLE
BUG: Show readable default for `fmu sync --help`

### DIFF
--- a/src/fmu_settings_cli/sync/cli.py
+++ b/src/fmu_settings_cli/sync/cli.py
@@ -33,6 +33,7 @@ def sync(
             "-f",
             help="Path to FMU Setting revision to sync *from*",
             default_factory=Path.cwd,
+            show_default="current directory",
         ),
     ],
     ctx: typer.Context,

--- a/tests/test_sync/test_sync_cli.py
+++ b/tests/test_sync/test_sync_cli.py
@@ -26,6 +26,8 @@ def test_sync_cmd_with_help(patch_ensure_port: Generator[None]) -> None:
     assert "Sync the contents of the .fmu folder" in result.stdout
     assert "--from" in result.stdout
     assert "--to" in result.stdout
+    assert "current directory" in result.stdout
+    assert "bound method PathBase.cwd" not in result.stdout
 
 
 def test_sync_cmd_with_no_options() -> None:


### PR DESCRIPTION
Resolves #93 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
