### PR TITLE
ENH: Alert users to set up stratigraphy after `fmu init`

### DIFF
--- a/src/fmu_settings_cli/init/cli.py
+++ b/src/fmu_settings_cli/init/cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 
 from fmu_settings_cli.prints import (
     error,
+    info,
     success,
     validation_error,
     validation_warning,
@@ -53,7 +54,7 @@ def is_fmu_project(path: Path) -> tuple[bool, list[str]]:
 
 
 @init_cmd.callback(invoke_without_command=True)
-def init(
+def init(  # noqa: PLR0912
     ctx: typer.Context,
     force: Annotated[
         bool,
@@ -123,7 +124,7 @@ def init(
         success("Successfully imported masterdata from global config/variables.")
 
     try:
-        init_fmu_directory(cwd, global_config=global_config)
+        fmu_dir = init_fmu_directory(cwd, global_config=global_config)
     except FileExistsError as e:
         error(
             "Unable to create .fmu directory.",
@@ -152,4 +153,12 @@ def init(
         )
         raise typer.Abort from e
 
+    if fmu_dir.config.load().masterdata is not None:
+        info(
+            "Project stratigraphy was not imported by 'fmu init'.",
+            suggestion=(
+                "Open 'fmu settings' to import stratigraphy from RMS and map it "
+                "to SMDA."
+            ),
+        )
     success("All done! You can now use the 'fmu settings' application.")

--- a/src/fmu_settings_cli/prints.py
+++ b/src/fmu_settings_cli/prints.py
@@ -112,7 +112,7 @@ def warning(
         suggestion: Optional suggestion or additional info after the reason
         **kwargs: Additional arguments to past to console.print().
     """
-    _print_stderr(_WARNING, *content, reason=reason, suggestion=reason, **kwargs)
+    _print_stderr(_WARNING, *content, reason=reason, suggestion=suggestion, **kwargs)
 
 
 def error(

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -148,6 +148,8 @@ def test_init_adds_global_variables_with_masterdata(
     assert result.exit_code == 0
     assert "Success: Successfully imported masterdata" in result.stdout
     assert "Success: All done!" in result.stdout
+    assert "Info: Project stratigraphy was not imported by 'fmu init'." in result.stdout
+    assert "Open 'fmu settings' to import stratigraphy from RMS" in result.stdout
 
     fmu_dir = find_nearest_fmu_directory()
     fmu_dir_cfg = fmu_dir.config.load()

--- a/tests/test_prints.py
+++ b/tests/test_prints.py
@@ -38,12 +38,13 @@ def test_success_and_info_print_to_stdout() -> None:
 def test_warning_and_error_print_to_stderr() -> None:
     """Tests that 'warning' and 'error' print as expected."""
     with patch("sys.stderr", new=StringIO()) as mock_stderr:
-        warning("Bad", reason="Because")
+        warning("Bad", reason="Because", suggestion="Do this next")
         error("Failed", suggestion="Fix it")
 
         err = mock_stderr.getvalue()
         assert "Warning: Bad" in err
         assert "Reason: Because" in err
+        assert "→ Do this next" in err
         assert "Error: Failed" in err
         assert "→ Fix it" in err
 


### PR DESCRIPTION
Resolves #84 

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [ ] All debug prints and unnecessary comments removed
- [ ] Docstrings are correct and updated
- [ ] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
