### PR TITLE
ENH: Improve error message when importing invalid masterdata

### DIFF
--- a/src/fmu_settings_cli/init/cli.py
+++ b/src/fmu_settings_cli/init/cli.py
@@ -129,10 +129,14 @@ def init(  # noqa: PLR0912
                     "Settings by running and opening 'fmu settings'."
                 ),
             )
-        except InvalidGlobalConfigurationError as e:
+        except InvalidGlobalConfigurationError:
             warning(
                 "Unable to import masterdata.",
-                reason=str(e),
+                reason=(
+                    "The global config contains data that is not valid SMDA "
+                    "masterdata. This can happen when the file contains placeholder "
+                    "values or Drogon data."
+                ),
                 suggestion=(
                     "You will need to establish valid SMDA masterdata in FMU "
                     "Settings by running and opening 'fmu settings'."

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -226,8 +226,13 @@ def test_init_raises_when_import_drogon_masterdata(
 
     result = runner.invoke(app, ["init"])
     assert result.exit_code == 0
+    stderr = " ".join(result.stderr.split())
     assert "Warning: Unable to import masterdata" in result.stderr
-    assert "Reason: Invalid name in 'model': Drogon" in result.stderr
+    assert (
+        "Reason: The global config contains data that is not valid SMDA "
+        "masterdata." in stderr
+    )
+    assert "placeholder values or Drogon data" in stderr
     assert "Success: All done!" in result.stdout
 
 


### PR DESCRIPTION
Resolves #107 

Improve the error message when importing masterdata with Drogon data. Instead of using error message from `fmu-settings` (e.g. "Invalid name in 'model'...), we tell a generic error that masterdata is invalid because it has Drogon data.

## Checklist

- [ ] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
