### PR TITLE
ENH: Use public fmu.settings API instead of private module path

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fmu-datamodels",
-    "fmu-settings>=0.28.0", # minimum version with project path validation in `fmu init` 
+    "fmu-settings>=0.32.1", # minimum version with project path validation in `fmu init`
     "fmu-settings-api",
     "fmu-settings-gui",
     "rich",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "fmu-datamodels",
-    "fmu-settings>=0.32.1", # minimum version with project path validation in `fmu init`
+    "fmu-settings>=0.32.1", # minimum version with public init/global config API exports
     "fmu-settings-api",
     "fmu-settings-gui",
     "rich",

--- a/src/fmu_settings_cli/__main__.py
+++ b/src/fmu_settings_cli/__main__.py
@@ -3,7 +3,7 @@
 import contextlib
 
 import typer
-from fmu.settings._init import init_user_fmu_directory
+from fmu.settings import init_user_fmu_directory
 
 from .copy.cli import copy_cmd
 from .init import init_cmd

--- a/src/fmu_settings_cli/copy/copy.py
+++ b/src/fmu_settings_cli/copy/copy.py
@@ -15,8 +15,7 @@ from pathlib import Path
 from typing import Self
 
 import typer
-from fmu.settings import get_fmu_directory
-from fmu.settings._init import init_fmu_directory
+from fmu.settings import get_fmu_directory, init_fmu_directory
 
 from fmu_settings_cli.prints import error, info, warning
 

--- a/src/fmu_settings_cli/init/cli.py
+++ b/src/fmu_settings_cli/init/cli.py
@@ -4,12 +4,10 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from fmu.settings._global_config import (
+from fmu.settings import (
+    InvalidFMUProjectPathError,
     InvalidGlobalConfigurationError,
     find_global_config,
-)
-from fmu.settings._init import (
-    InvalidFMUProjectPathError,
     init_fmu_directory,
 )
 from pydantic import ValidationError

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,8 +26,11 @@ from fmu.datamodels.fmu_results.global_configuration import (
     Stratigraphy,
     StratigraphyElement,
 )
-from fmu.settings import ProjectFMUDirectory
-from fmu.settings._init import REQUIRED_FMU_PROJECT_SUBDIRS, init_fmu_directory
+from fmu.settings import (
+    REQUIRED_FMU_PROJECT_SUBDIRS,
+    ProjectFMUDirectory,
+    init_fmu_directory,
+)
 from pytest import MonkeyPatch
 
 from fmu_settings_cli.settings import constants

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -5,39 +5,18 @@ from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
-import pytest
 import yaml
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
 from fmu.settings import (
     REQUIRED_FMU_PROJECT_SUBDIRS,
     find_nearest_fmu_directory,
 )
-from fmu.settings._init import is_fmu_project
 from pydantic import ValidationError
 from typer.testing import CliRunner
 
 from fmu_settings_cli.__main__ import app
 
 runner = CliRunner()
-
-
-@pytest.mark.parametrize(
-    "dirs, expected",
-    [
-        (["foo"], (False, list(REQUIRED_FMU_PROJECT_SUBDIRS))),
-        (["foo/ert"], (False, list(REQUIRED_FMU_PROJECT_SUBDIRS))),
-        (["ertt"], (False, list(REQUIRED_FMU_PROJECT_SUBDIRS))),
-        (REQUIRED_FMU_PROJECT_SUBDIRS, (True, [])),
-    ],
-)
-def test_is_fmu_project(
-    dirs: list[str], expected: tuple[bool, list[str]], in_tmp_path: Path
-) -> None:
-    """Tests is_fmu_project."""
-    for dir_ in dirs:
-        (in_tmp_path / dir_).mkdir(parents=True, exist_ok=True)
-
-    assert is_fmu_project(in_tmp_path) == expected
 
 
 def test_init_creates_user_fmu_if_exist(in_tmp_path: Path) -> None:

--- a/tests/test_init/test_init_main.py
+++ b/tests/test_init/test_init_main.py
@@ -8,8 +8,11 @@ from unittest.mock import patch
 import pytest
 import yaml
 from fmu.datamodels.fmu_results.global_configuration import GlobalConfiguration
-from fmu.settings import find_nearest_fmu_directory
-from fmu.settings._init import REQUIRED_FMU_PROJECT_SUBDIRS, is_fmu_project
+from fmu.settings import (
+    REQUIRED_FMU_PROJECT_SUBDIRS,
+    find_nearest_fmu_directory,
+)
+from fmu.settings._init import is_fmu_project
 from pydantic import ValidationError
 from typer.testing import CliRunner
 

--- a/uv.lock
+++ b/uv.lock
@@ -348,7 +348,7 @@ wheels = [
 
 [[package]]
 name = "fmu-settings"
-version = "0.31.0"
+version = "0.32.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -358,9 +358,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/70/9a5910411b8ae0cb55fb9cfc4f51e05b874c7b26cd9ac6e86a50d91bc272/fmu_settings-0.31.0.tar.gz", hash = "sha256:bf211c865b6738c697c6f00cc285cd504bd6ecdd2b5ce84f2bd44afd85ace9bc", size = 773182, upload-time = "2026-05-13T06:37:47.754Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/84/db33f98a4708ad3bd4598234bd22513a3cabb9f4a49af7b9bf19b7dddf57/fmu_settings-0.32.1.tar.gz", hash = "sha256:0c052eed3ba2391ec37085993fea48a3ca1b67250e841ae64a4b26a24d398614", size = 777755, upload-time = "2026-06-02T11:51:02.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/47/d9/3e274b64d02101dda2e67be9f212ac10ef4ef4f392e501325d3b919a166d/fmu_settings-0.31.0-py3-none-any.whl", hash = "sha256:03c809223e24c2aec471c47b7b4866379258d3449799d21be73c27d19c732f11", size = 60259, upload-time = "2026-05-13T06:37:45.851Z" },
+    { url = "https://files.pythonhosted.org/packages/45/d5/337712b17a0726e1fb24b40fec3b908dce4c4fa670d2fa1fdf342cc2aa45/fmu_settings-0.32.1-py3-none-any.whl", hash = "sha256:60dc8955b5ef1a3a5708f1d693879dcfe23a686b818ce9507135f443c3458501", size = 61091, upload-time = "2026-06-02T11:51:01.079Z" },
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fmu-datamodels" },
-    { name = "fmu-settings", specifier = ">=0.28.0" },
+    { name = "fmu-settings", specifier = ">=0.32.1" },
     { name = "fmu-settings-api" },
     { name = "fmu-settings-gui" },
     { name = "mypy", marker = "extra == 'dev'" },


### PR DESCRIPTION
Replace direct imports from `fmu.settings._init` with imports from the public `fmu.settings` namespace across source and test files.

- `init_user_fmu_directory`, `init_fmu_directory`, `InvalidFMUProjectPathError`
- `REQUIRED_FMU_PROJECT_SUBDIRS`, `ProjectFMUDirectory`
- Removed `test_is_fmu_project` and its `is_fmu_project` import from
`fmu.settings._init`, as testing private API internals is out of scope.

Resolves #129 

## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [x] Added comments on this PR where appropriate to help reviewers
- [x] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
