### PR TITLE
BUG: Delay browser launch until API health check passes

### DIFF
--- a/src/fmu_settings_cli/settings/main.py
+++ b/src/fmu_settings_cli/settings/main.py
@@ -2,6 +2,8 @@
 
 import contextlib
 import signal
+import time
+import urllib.request
 import webbrowser
 from concurrent.futures import ProcessPoolExecutor, as_completed
 
@@ -12,6 +14,8 @@ from ._utils import (
 )
 from .api_server import start_api_server
 from .gui_server import start_gui_server
+
+API_HEALTH_WAIT_TIMEOUT_SECONDS = 5
 
 
 def init_worker() -> None:  # pragma: no cover
@@ -61,6 +65,8 @@ def start_api_and_gui(  # noqa: PLR0913 too many args
             }
 
             is_start_up = True
+            api_health_url = f"http://{host}:{api_port}/health"
+            api_health_deadline = time.monotonic() + API_HEALTH_WAIT_TIMEOUT_SECONDS
             while True:
                 try:
                     # Check once a half second if either the GUI or API process have
@@ -98,11 +104,28 @@ def start_api_and_gui(  # noqa: PLR0913 too many args
                     # within the 0.5 second timeout, and so raises a TimeoutError. But
                     # grab all exceptions more broadly.
                     if is_start_up:
-                        # Defer this message until we are certain GUI/API have started
-                        # without initial errors.
-                        success("FMU Settings is running. Press CTRL+C to quit")
-                        webbrowser.open(create_authorized_url(token, host, gui_port))
-                        is_start_up = False
+                        try:
+                            with urllib.request.urlopen(
+                                api_health_url, timeout=0.5
+                            ) as response:
+                                is_api_ready = response.status == 200
+                        except OSError:
+                            is_api_ready = False
+
+                        if is_api_ready:
+                            success("FMU Settings is running. Press CTRL+C to quit")
+                            webbrowser.open(
+                                create_authorized_url(token, host, gui_port)
+                            )
+                            is_start_up = False
+                        elif time.monotonic() >= api_health_deadline:
+                            error(
+                                "API did not become ready within "
+                                f"{API_HEALTH_WAIT_TIMEOUT_SECONDS} seconds. "
+                                "Shutting down FMU Settings.",
+                                reason="Health check failed.",
+                            )
+                            break
                     continue
 
         except KeyboardInterrupt:

--- a/src/fmu_settings_cli/settings/main.py
+++ b/src/fmu_settings_cli/settings/main.py
@@ -100,9 +100,9 @@ def start_api_and_gui(  # noqa: PLR0913 too many args
                         error(f"{service} failed with: {e}")
                     break
                 except Exception:
-                    # This is the valid case, where the server future has not completed
-                    # within the 0.5 second timeout, and so raises a TimeoutError. But
-                    # grab all exceptions more broadly.
+                    # This is the valid case, where no server future completed within
+                    # the 0.5 second timeout. While starting up, keep probing the API
+                    # health endpoint and open the GUI only after it returns HTTP 200.
                     if is_start_up:
                         try:
                             with urllib.request.urlopen(

--- a/tests/test_settings/test_settings_main.py
+++ b/tests/test_settings/test_settings_main.py
@@ -152,7 +152,7 @@ def test_keyboard_interrupt_in_process_executor(
 def test_start_api_and_gui_does_not_open_browser_when_api_is_not_ready(
     default_settings_args: dict[str, Any], capsys: CaptureFixture[str]
 ) -> None:
-    """Tests that the browser opens only after the API health check succeeds."""
+    """Tests that the browser stays closed when the API health check fails."""
     token = generate_auth_token()
 
     with (
@@ -187,6 +187,64 @@ def test_start_api_and_gui_does_not_open_browser_when_api_is_not_ready(
             iter(()),
             iter([mock_api_future]),
         ]
+
+        start_api_and_gui(token, *default_settings_args.values())
+
+    mock_start_api_server.assert_not_called()
+    mock_start_gui_server.assert_not_called()
+    mock_urlopen.assert_called_once_with(
+        f"http://{default_settings_args['host']}:"
+        f"{default_settings_args['api_port']}/health",
+        timeout=0.5,
+    )
+    mock_webbrowser_open.assert_not_called()
+
+    captured = capsys.readouterr()
+    stderr = captured.err.replace("\n", " ")
+    assert "API did not become ready within 5 seconds." in stderr
+    assert "Shutting down FMU Settings." in stderr
+    assert "Health check failed." in stderr
+
+
+def test_start_api_and_gui_does_not_open_browser_when_api_is_unhealthy(
+    default_settings_args: dict[str, Any], capsys: CaptureFixture[str]
+) -> None:
+    """Tests that the browser stays closed when the API health status is not 200."""
+    token = generate_auth_token()
+
+    with (
+        patch("fmu_settings_cli.settings.main.ProcessPoolExecutor") as mock_executor,
+        patch("fmu_settings_cli.settings.main.as_completed") as mock_as_completed,
+        patch(
+            "fmu_settings_cli.settings.main.start_api_server"
+        ) as mock_start_api_server,
+        patch(
+            "fmu_settings_cli.settings.main.start_gui_server"
+        ) as mock_start_gui_server,
+        patch("fmu_settings_cli.settings.main.urllib.request.urlopen") as mock_urlopen,
+        patch(
+            "fmu_settings_cli.settings.main.time.monotonic",
+            side_effect=[0, 6],
+        ),
+        patch("fmu_settings_cli.settings.main.webbrowser.open") as mock_webbrowser_open,
+    ):
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value.__enter__.return_value = mock_executor_instance
+
+        mock_api_future = MagicMock()
+        mock_gui_future = MagicMock()
+        mock_executor_instance.submit.side_effect = [
+            mock_api_future,
+            mock_gui_future,
+        ]
+        mock_as_completed.side_effect = [
+            iter(()),
+            iter([mock_api_future]),
+        ]
+
+        mock_health_response = MagicMock()
+        mock_health_response.__enter__.return_value.status = 503
+        mock_urlopen.return_value = mock_health_response
 
         start_api_and_gui(token, *default_settings_args.values())
 

--- a/tests/test_settings/test_settings_main.py
+++ b/tests/test_settings/test_settings_main.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from time import sleep
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from pytest import CaptureFixture
@@ -31,8 +31,16 @@ def test_start_api_and_gui_processes(default_settings_args: Any) -> None:
         patch(
             "fmu_settings_cli.settings.main.start_gui_server"
         ) as mock_start_gui_server,
+        patch("fmu_settings_cli.settings.main.urllib.request.urlopen") as mock_urlopen,
         patch("fmu_settings_cli.settings.main.webbrowser.open") as mock_webbrowser_open,
     ):
+        startup_calls = MagicMock()
+        startup_calls.attach_mock(mock_urlopen, "urlopen")
+        startup_calls.attach_mock(mock_webbrowser_open, "browser_open")
+        mock_health_response = MagicMock()
+        mock_health_response.__enter__.return_value.status = 200
+        mock_urlopen.return_value = mock_health_response
+        mock_webbrowser_open.return_value = True
         mock_executor_instance = MagicMock()
         # Patch over the ProcessPoolExecutor. This requires that objects submitted
         # to it are pickle-able, and mock objects _are not_. So extra mocking is
@@ -55,6 +63,15 @@ def test_start_api_and_gui_processes(default_settings_args: Any) -> None:
         # Whew. Start it up then do assertions.
         start_api_and_gui(token, *default_settings_args.values())
 
+        expected_api_health_url = (
+            f"http://{default_settings_args['host']}:"
+            f"{default_settings_args['api_port']}/health"
+        )
+        expected_browser_url = (
+            f"http://{default_settings_args['host']}:"
+            f"{default_settings_args['gui_port']}/#token={token}"
+        )
+
         mock_executor.assert_called_once_with(max_workers=2, initializer=init_worker)
 
         mock_executor_instance.submit.assert_any_call(
@@ -75,9 +92,11 @@ def test_start_api_and_gui_processes(default_settings_args: Any) -> None:
             log_level=default_settings_args["log_level"],
         )
         assert mock_executor_instance.submit.call_count == expected_server_count
-        mock_webbrowser_open.assert_called_once_with(
-            f"http://{default_settings_args['host']}:{default_settings_args['gui_port']}/#token={token}",
-        )
+        mock_urlopen.assert_called_once_with(expected_api_health_url, timeout=0.5)
+        mock_webbrowser_open.assert_called_once_with(expected_browser_url)
+        assert startup_calls.mock_calls.index(
+            call.urlopen(expected_api_health_url, timeout=0.5)
+        ) < startup_calls.mock_calls.index(call.browser_open(expected_browser_url))
 
         # Check this is called, but mostly because it blocks if not mocked
         assert mock_as_completed.call_count == expected_poll_count
@@ -97,8 +116,12 @@ def test_keyboard_interrupt_in_process_executor(
         patch(
             "fmu_settings_cli.settings.main.start_gui_server"
         ) as mock_start_gui_server,
+        patch("fmu_settings_cli.settings.main.urllib.request.urlopen") as mock_urlopen,
         patch("fmu_settings_cli.settings.main.webbrowser.open") as mock_webbrowser_open,
     ):
+        mock_health_response = MagicMock()
+        mock_health_response.__enter__.return_value.status = 200
+        mock_urlopen.return_value = mock_health_response
         mock_start_api_server.side_effect = lambda *args, **kwargs: None
         mock_start_gui_server.side_effect = lambda *args, **kwargs: None
         mock_webbrowser_open.return_value = True
@@ -108,7 +131,10 @@ def test_keyboard_interrupt_in_process_executor(
 
         mock_api_future = MagicMock()
         mock_gui_future = MagicMock()
-        mock_as_completed.return_value = iter(())
+        mock_as_completed.side_effect = [
+            iter(()),
+            iter([mock_api_future]),
+        ]
         mock_webbrowser_open.side_effect = KeyboardInterrupt()
 
         mock_executor_instance.submit.side_effect = [
@@ -121,6 +147,63 @@ def test_keyboard_interrupt_in_process_executor(
     captured = capsys.readouterr()
     stdout = captured.out.replace("\n", " ").replace("  ", " ")
     assert "Shutting down FMU Settings ..." in stdout
+
+
+def test_start_api_and_gui_does_not_open_browser_when_api_is_not_ready(
+    default_settings_args: dict[str, Any], capsys: CaptureFixture[str]
+) -> None:
+    """Tests that the browser opens only after the API health check succeeds."""
+    token = generate_auth_token()
+
+    with (
+        patch("fmu_settings_cli.settings.main.ProcessPoolExecutor") as mock_executor,
+        patch("fmu_settings_cli.settings.main.as_completed") as mock_as_completed,
+        patch(
+            "fmu_settings_cli.settings.main.start_api_server"
+        ) as mock_start_api_server,
+        patch(
+            "fmu_settings_cli.settings.main.start_gui_server"
+        ) as mock_start_gui_server,
+        patch(
+            "fmu_settings_cli.settings.main.urllib.request.urlopen",
+            side_effect=OSError,
+        ) as mock_urlopen,
+        patch(
+            "fmu_settings_cli.settings.main.time.monotonic",
+            side_effect=[0, 6],
+        ),
+        patch("fmu_settings_cli.settings.main.webbrowser.open") as mock_webbrowser_open,
+    ):
+        mock_executor_instance = MagicMock()
+        mock_executor.return_value.__enter__.return_value = mock_executor_instance
+
+        mock_api_future = MagicMock()
+        mock_gui_future = MagicMock()
+        mock_executor_instance.submit.side_effect = [
+            mock_api_future,
+            mock_gui_future,
+        ]
+        mock_as_completed.side_effect = [
+            iter(()),
+            iter([mock_api_future]),
+        ]
+
+        start_api_and_gui(token, *default_settings_args.values())
+
+    mock_start_api_server.assert_not_called()
+    mock_start_gui_server.assert_not_called()
+    mock_urlopen.assert_called_once_with(
+        f"http://{default_settings_args['host']}:"
+        f"{default_settings_args['api_port']}/health",
+        timeout=0.5,
+    )
+    mock_webbrowser_open.assert_not_called()
+
+    captured = capsys.readouterr()
+    stderr = captured.err.replace("\n", " ")
+    assert "API did not become ready within 5 seconds." in stderr
+    assert "Shutting down FMU Settings." in stderr
+    assert "Health check failed." in stderr
 
 
 def _bad_exit_early(*args: Any, **kwargs: Any) -> None:


### PR DESCRIPTION
Related to https://github.com/equinor/fmu-settings-gui/issues/440

After the CLI confirmed that both GUI and API process are still alive after 0.5s, it will ping API health endpoint every 0.5s until 5s has passed. If health is OK, then open browser, if not OK until 5s has passed, it shutdown FMU Settings app.

<img width="448" height="270" alt="image" src="https://github.com/user-attachments/assets/35e0e0d2-70c9-47cf-8eca-fbbbb501f477" />


## Checklist

- [x] Tests added (if not, comment why)
- [x] Test coverage equal or up from main (run pytest with `--cov=src/ --cov-report term-missing`)
- [x] If not squash merging, every commit passes tests
- [x] Appropriate [commit prefix](https://upgraded-funicular-eywe4gy.pages.github.io/developing/#commit-prefixes) and precise commit message used
- [x] All debug prints and unnecessary comments removed
- [x] Docstrings are correct and updated
- [x] Documentation is updated, if necessary
- [x] Latest main rebased/merged into branch
- [ ] Added comments on this PR where appropriate to help reviewers
- [ ] Moved issue status on project board
- [x] Checked the boxes in this checklist ✅
